### PR TITLE
Refactor views for events and users

### DIFF
--- a/backend/api-spec.json
+++ b/backend/api-spec.json
@@ -69,14 +69,7 @@
             }
           }
         ],
-        "responses": {
-          "201": {
-            "description": "Created"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
+        "responses": {}
       },
       "get": {
         "tags": [
@@ -84,14 +77,7 @@
         ],
         "description": "",
         "parameters": [],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
+        "responses": {}
       }
     },
     "/users/{userID}": {
@@ -108,14 +94,7 @@
             "type": "string"
           }
         ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
+        "responses": {}
       },
       "put": {
         "tags": [
@@ -130,14 +109,7 @@
             "type": "string"
           }
         ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
+        "responses": {}
       },
       "get": {
         "tags": [
@@ -152,14 +124,7 @@
             "type": "string"
           }
         ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
+        "responses": {}
       }
     },
     "/users/pagination": {
@@ -180,14 +145,7 @@
             "type": "string"
           }
         ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
+        "responses": {}
       }
     },
     "/users/search": {
@@ -197,14 +155,7 @@
         ],
         "description": "",
         "parameters": [],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
+        "responses": {}
       }
     },
     "/users/sorting": {
@@ -220,14 +171,7 @@
             "type": "string"
           }
         ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
+        "responses": {}
       }
     },
     "/users/{userID}/profile": {
@@ -244,14 +188,7 @@
             "type": "string"
           }
         ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
+        "responses": {}
       }
     },
     "/users/{userID}/role": {
@@ -268,14 +205,7 @@
             "type": "string"
           }
         ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
+        "responses": {}
       }
     },
     "/users/{userID}/preferences": {
@@ -292,14 +222,7 @@
             "type": "string"
           }
         ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
+        "responses": {}
       }
     },
     "/users/{userID}/created": {
@@ -316,14 +239,7 @@
             "type": "string"
           }
         ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
+        "responses": {}
       }
     },
     "/users/{userID}/registered": {
@@ -340,14 +256,7 @@
             "type": "string"
           }
         ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
+        "responses": {}
       }
     },
     "/users/{userID}/hours": {
@@ -364,14 +273,7 @@
             "type": "string"
           }
         ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
+        "responses": {}
       }
     },
     "/users/{userid}/profile": {
@@ -388,14 +290,7 @@
             "type": "string"
           }
         ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
+        "responses": {}
       }
     },
     "/users/{userid}/preferences": {
@@ -412,14 +307,7 @@
             "type": "string"
           }
         ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
+        "responses": {}
       }
     },
     "/users/{userid}/status/{status}": {
@@ -442,14 +330,7 @@
             "type": "string"
           }
         ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
+        "responses": {}
       }
     },
     "/users/{userid}/role/{role}": {
@@ -472,14 +353,7 @@
             "type": "string"
           }
         ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
+        "responses": {}
       }
     },
     "/users/{userid}/hours/{hours}": {
@@ -502,17 +376,10 @@
             "type": "string"
           }
         ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
+        "responses": {}
       }
     },
-    "/events/create/{userID}": {
+    "/events/{eventID}": {
       "post": {
         "tags": [
           "Events"
@@ -520,23 +387,14 @@
         "description": "",
         "parameters": [
           {
-            "name": "userID",
+            "name": "eventID",
             "in": "path",
             "required": true,
             "type": "string"
           }
         ],
-        "responses": {
-          "201": {
-            "description": "Created"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
-      }
-    },
-    "/events/{eventID}": {
+        "responses": {}
+      },
       "put": {
         "tags": [
           "Events"
@@ -550,14 +408,7 @@
             "type": "string"
           }
         ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
+        "responses": {}
       }
     },
     "/events/delete/{eventID}": {
@@ -574,14 +425,7 @@
             "type": "string"
           }
         ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
+        "responses": {}
       }
     },
     "/events/": {
@@ -591,14 +435,7 @@
         ],
         "description": "",
         "parameters": [],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
+        "responses": {}
       }
     },
     "/events/upcoming": {
@@ -608,14 +445,7 @@
         ],
         "description": "",
         "parameters": [],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
+        "responses": {}
       }
     },
     "/events/current": {
@@ -625,14 +455,7 @@
         ],
         "description": "",
         "parameters": [],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
+        "responses": {}
       }
     },
     "/events/past": {
@@ -642,14 +465,7 @@
         ],
         "description": "",
         "parameters": [],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
+        "responses": {}
       }
     },
     "/events/{eventid}": {
@@ -666,14 +482,7 @@
             "type": "string"
           }
         ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
+        "responses": {}
       }
     },
     "/events/{eventid}/attendees": {
@@ -690,14 +499,7 @@
             "type": "string"
           }
         ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
+        "responses": {}
       }
     },
     "/events/{eventid}/{attendeeid}": {
@@ -720,14 +522,7 @@
             "type": "string"
           }
         ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
+        "responses": {}
       }
     },
     "/events/{eventid}/attendees/{attendeeid}": {
@@ -750,14 +545,7 @@
             "type": "string"
           }
         ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
+        "responses": {}
       }
     },
     "/events/{eventid}/status/{status}": {
@@ -780,14 +568,7 @@
             "type": "string"
           }
         ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
+        "responses": {}
       }
     },
     "/events/{eventid}/owner/{ownerid}": {
@@ -810,14 +591,7 @@
             "type": "string"
           }
         ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
+        "responses": {}
       }
     },
     "/events/{eventid}/attendees/{attendeeid}/confirm": {
@@ -840,14 +614,7 @@
             "type": "string"
           }
         ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
+        "responses": {}
       }
     }
   }

--- a/backend/api-spec.json
+++ b/backend/api-spec.json
@@ -80,7 +80,7 @@
         "responses": {}
       }
     },
-    "/users/{userID}": {
+    "/users/{userid}": {
       "delete": {
         "tags": [
           "Users"
@@ -88,7 +88,7 @@
         "description": "",
         "parameters": [
           {
-            "name": "userID",
+            "name": "userid",
             "in": "path",
             "required": true,
             "type": "string"
@@ -103,7 +103,7 @@
         "description": "",
         "parameters": [
           {
-            "name": "userID",
+            "name": "userid",
             "in": "path",
             "required": true,
             "type": "string"
@@ -118,7 +118,7 @@
         "description": "",
         "parameters": [
           {
-            "name": "userID",
+            "name": "userid",
             "in": "path",
             "required": true,
             "type": "string"
@@ -174,109 +174,22 @@
         "responses": {}
       }
     },
-    "/users/{userID}/profile": {
-      "get": {
-        "tags": [
-          "Users"
-        ],
-        "description": "",
-        "parameters": [
-          {
-            "name": "userID",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {}
-      }
-    },
-    "/users/{userID}/role": {
-      "get": {
-        "tags": [
-          "Users"
-        ],
-        "description": "",
-        "parameters": [
-          {
-            "name": "userID",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {}
-      }
-    },
-    "/users/{userID}/preferences": {
-      "get": {
-        "tags": [
-          "Users"
-        ],
-        "description": "",
-        "parameters": [
-          {
-            "name": "userID",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {}
-      }
-    },
-    "/users/{userID}/created": {
-      "get": {
-        "tags": [
-          "Users"
-        ],
-        "description": "",
-        "parameters": [
-          {
-            "name": "userID",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {}
-      }
-    },
-    "/users/{userID}/registered": {
-      "get": {
-        "tags": [
-          "Users"
-        ],
-        "description": "",
-        "parameters": [
-          {
-            "name": "userID",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {}
-      }
-    },
-    "/users/{userID}/hours": {
-      "get": {
-        "tags": [
-          "Users"
-        ],
-        "description": "",
-        "parameters": [
-          {
-            "name": "userID",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {}
-      }
-    },
     "/users/{userid}/profile": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "userid",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {}
+      },
       "put": {
         "tags": [
           "Users"
@@ -293,8 +206,91 @@
         "responses": {}
       }
     },
+    "/users/{userid}/role": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "userid",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {}
+      }
+    },
     "/users/{userid}/preferences": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "userid",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {}
+      },
       "put": {
+        "tags": [
+          "Users"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "userid",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/users/{userid}/created": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "userid",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/users/{userid}/registered": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "userid",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/users/{userid}/hours": {
+      "get": {
         "tags": [
           "Users"
         ],
@@ -379,7 +375,7 @@
         "responses": {}
       }
     },
-    "/events/{eventID}": {
+    "/events/{eventid}": {
       "post": {
         "tags": [
           "Events"
@@ -387,7 +383,7 @@
         "description": "",
         "parameters": [
           {
-            "name": "eventID",
+            "name": "eventid",
             "in": "path",
             "required": true,
             "type": "string"
@@ -402,16 +398,14 @@
         "description": "",
         "parameters": [
           {
-            "name": "eventID",
+            "name": "eventid",
             "in": "path",
             "required": true,
             "type": "string"
           }
         ],
         "responses": {}
-      }
-    },
-    "/events/delete/{eventID}": {
+      },
       "delete": {
         "tags": [
           "Events"
@@ -419,7 +413,22 @@
         "description": "",
         "parameters": [
           {
-            "name": "eventID",
+            "name": "eventid",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {}
+      },
+      "get": {
+        "tags": [
+          "Events"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "eventid",
             "in": "path",
             "required": true,
             "type": "string"
@@ -468,23 +477,6 @@
         "responses": {}
       }
     },
-    "/events/{eventid}": {
-      "get": {
-        "tags": [
-          "Events"
-        ],
-        "description": "",
-        "parameters": [
-          {
-            "name": "eventid",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {}
-      }
-    },
     "/events/{eventid}/attendees": {
       "get": {
         "tags": [
@@ -502,7 +494,7 @@
         "responses": {}
       }
     },
-    "/events/{eventid}/{attendeeid}": {
+    "/events/{eventid}/attendees/{attendeeid}": {
       "post": {
         "tags": [
           "Events"
@@ -523,9 +515,7 @@
           }
         ],
         "responses": {}
-      }
-    },
-    "/events/{eventid}/attendees/{attendeeid}": {
+      },
       "delete": {
         "tags": [
           "Events"

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,11 +7,13 @@
   "dependencies": {
     "@prisma/client": "^4.9.0",
     "@typegoose/typegoose": "^10.0.0",
+    "@types/cors": "^2.8.13",
     "@types/express": "^4.17.17",
     "@types/jest": "^29.2.5",
     "@types/node": "^18.11.18",
     "@types/swagger-ui-express": "^4.1.3",
     "body-parser": "^1.20.1",
+    "cors": "^2.8.5",
     "date-fns": "^2.29.3",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",

--- a/backend/src/events/views.ts
+++ b/backend/src/events/views.ts
@@ -10,21 +10,21 @@ if (process.env.NODE_ENV !== "test") {
   eventRouter.use(auth as RequestHandler);
 }
 
-eventRouter.post("/:eventID", async (req: Request, res: Response) => {
+eventRouter.post("/:eventid", async (req: Request, res: Response) => {
   // #swagger.tags = ['Events']
-  attempt(res, 201, () => eventController.createEvent(req.params.eventID, req));
+  attempt(res, 201, () => eventController.createEvent(req.params.eventid, req));
 });
 
-eventRouter.put("/:eventID", async (req: Request, res: Response) => {
+eventRouter.put("/:eventid", async (req: Request, res: Response) => {
   // #swagger.tags = ['Events']
   attempt(res, 200, () =>
-    eventController.updateEvent(req.params.eventID, req.body)
+    eventController.updateEvent(req.params.eventid, req.body)
   );
 });
 
-eventRouter.delete("/:eventID", async (req: Request, res: Response) => {
+eventRouter.delete("/:eventid", async (req: Request, res: Response) => {
   // #swagger.tags = ['Events']
-  attempt(res, 200, () => eventController.deleteEvent(req.params.eventID));
+  attempt(res, 200, () => eventController.deleteEvent(req.params.eventid));
 });
 
 eventRouter.get("/", async (req: Request, res: Response) => {

--- a/backend/src/events/views.ts
+++ b/backend/src/events/views.ts
@@ -1,8 +1,7 @@
 import { Router, RequestHandler, Request, Response } from "express";
 import eventController from "./controllers";
 import { auth } from "../middleware/auth";
-
-import { errorJson, successJson } from "../utils/jsonResponses";
+import { attempt } from "../utils/helpers";
 
 const eventRouter = Router();
 
@@ -13,107 +12,58 @@ if (process.env.NODE_ENV !== "test") {
 
 eventRouter.post("/:eventID", async (req: Request, res: Response) => {
   // #swagger.tags = ['Events']
-  try {
-    res
-      .status(201)
-      .send(await eventController.createEvent(req.params.eventID, req));
-  } catch (error) {
-    res.status(500).send(errorJson(error));
-  }
+  attempt(res, 201, () => eventController.createEvent(req.params.eventID, req));
 });
 
 eventRouter.put("/:eventID", async (req: Request, res: Response) => {
   // #swagger.tags = ['Events']
-  try {
-    res
-      .status(200)
-      .send(await eventController.updateEvent(req.params.eventID, req.body));
-  } catch (error) {
-    res.status(500).send(errorJson(error));
-  }
+  attempt(res, 200, () =>
+    eventController.updateEvent(req.params.eventID, req.body)
+  );
 });
 
 eventRouter.delete("/delete/:eventID", async (req: Request, res: Response) => {
   // #swagger.tags = ['Events']
-  try {
-    res.status(200).send(await eventController.deleteEvent(req.params.eventID));
-  } catch (error) {
-    res.status(500).send(errorJson(error));
-  }
+  attempt(res, 200, () => eventController.deleteEvent(req.params.eventID));
 });
 
 eventRouter.get("/", async (req: Request, res: Response) => {
   // #swagger.tags = ['Events']
-  try {
-    res.status(200).send(await eventController.getEvents());
-  } catch (error) {
-    res.status(500).send(errorJson(error));
-  }
+  attempt(res, 200, () => eventController.getEvents());
 });
 
 eventRouter.get("/upcoming", async (req: Request, res: Response) => {
   // #swagger.tags = ['Events']
-  try {
-    res.status(200).send(await eventController.getUpcomingEvents());
-  } catch (error) {
-    res.status(500).send(errorJson(error));
-  }
+  attempt(res, 200, () => eventController.getUpcomingEvents());
 });
 
 eventRouter.get("/current", async (req: Request, res: Response) => {
   // #swagger.tags = ['Events']
-  try {
-    res.status(200).send(await eventController.getCurrentEvents());
-  } catch (error) {
-    res.status(500).send(errorJson(error));
-  }
+  attempt(res, 200, () => eventController.getCurrentEvents());
 });
 
 eventRouter.get("/past", async (req: Request, res: Response) => {
   // #swagger.tags = ['Events']
-  try {
-    res.status(200).send(await eventController.getPastEvents());
-  } catch (error) {
-    res.status(500).send(errorJson(error));
-  }
+  attempt(res, 200, () => eventController.getPastEvents());
 });
 
 eventRouter.get("/:eventid", async (req: Request, res: Response) => {
   // #swagger.tags = ['Events']
-  try {
-    res.status(200).send(await eventController.getEvent(req.params.eventid));
-  } catch (error) {
-    res.status(500).send(errorJson(error));
-  }
+  attempt(res, 200, () => eventController.getEvent(req.params.eventid));
 });
 
 eventRouter.get("/:eventid/attendees", async (req: Request, res: Response) => {
   // #swagger.tags = ['Events']
-  try {
-    res
-      .status(200)
-      .send(await eventController.getAttendees(req.params.eventid));
-  } catch (error) {
-    res.status(500).send(errorJson(error));
-  }
+  attempt(res, 200, () => eventController.getAttendees(req.params.eventid));
 });
 
 eventRouter.post(
   "/:eventid/:attendeeid",
   async (req: Request, res: Response) => {
     // #swagger.tags = ['Events']
-    try {
-      res
-        .status(200)
-        .send(
-          await eventController.addAttendee(
-            req.params.eventid,
-            req.params.attendeeid
-          )
-        );
-    } catch (error) {
-      res.status(500).send(errorJson(error));
-    }
+    attempt(res, 200, () =>
+      eventController.addAttendee(req.params.eventid, req.params.attendeeid)
+    );
   }
 );
 
@@ -121,18 +71,9 @@ eventRouter.delete(
   "/:eventid/attendees/:attendeeid",
   async (req: Request, res: Response) => {
     // #swagger.tags = ['Events']
-    try {
-      res
-        .status(200)
-        .send(
-          await eventController.deleteAttendee(
-            req.params.eventid,
-            req.params.attendeeid
-          )
-        );
-    } catch (error) {
-      res.status(500).send(errorJson(error));
-    }
+    attempt(res, 200, () =>
+      eventController.deleteAttendee(req.params.eventid, req.params.attendeeid)
+    );
   }
 );
 
@@ -140,18 +81,9 @@ eventRouter.patch(
   "/:eventid/status/:status",
   async (req: Request, res: Response) => {
     // #swagger.tags = ['Events']
-    try {
-      res
-        .status(200)
-        .send(
-          await eventController.updateEventStatus(
-            req.params.eventid,
-            req.params.status
-          )
-        );
-    } catch (error) {
-      res.status(500).send(errorJson(error));
-    }
+    attempt(res, 200, () =>
+      eventController.updateEventStatus(req.params.eventid, req.params.status)
+    );
   }
 );
 
@@ -159,18 +91,9 @@ eventRouter.patch(
   "/:eventid/owner/:ownerid",
   async (req: Request, res: Response) => {
     // #swagger.tags = ['Events']
-    try {
-      res
-        .status(200)
-        .send(
-          await eventController.updateEventOwner(
-            req.params.eventid,
-            req.params.ownerid
-          )
-        );
-    } catch (error) {
-      res.status(500).send(errorJson(error));
-    }
+    attempt(res, 200, () =>
+      eventController.updateEventOwner(req.params.eventid, req.params.ownerid)
+    );
   }
 );
 
@@ -178,18 +101,9 @@ eventRouter.patch(
   "/:eventid/attendees/:attendeeid/confirm",
   async (req: Request, res: Response) => {
     // #swagger.tags = ['Events']
-    try {
-      res
-        .status(200)
-        .send(
-          await eventController.confirmUser(
-            req.params.eventid,
-            req.params.attendeeid
-          )
-        );
-    } catch (error) {
-      res.status(500).send(errorJson(error));
-    }
+    attempt(res, 200, () =>
+      eventController.confirmUser(req.params.eventid, req.params.attendeeid)
+    );
   }
 );
 

--- a/backend/src/events/views.ts
+++ b/backend/src/events/views.ts
@@ -29,22 +29,22 @@ eventRouter.delete("/delete/:eventID", async (req: Request, res: Response) => {
 
 eventRouter.get("/", async (req: Request, res: Response) => {
   // #swagger.tags = ['Events']
-  attempt(res, 200, () => eventController.getEvents());
+  attempt(res, 200, eventController.getEvents);
 });
 
 eventRouter.get("/upcoming", async (req: Request, res: Response) => {
   // #swagger.tags = ['Events']
-  attempt(res, 200, () => eventController.getUpcomingEvents());
+  attempt(res, 200, eventController.getUpcomingEvents);
 });
 
 eventRouter.get("/current", async (req: Request, res: Response) => {
   // #swagger.tags = ['Events']
-  attempt(res, 200, () => eventController.getCurrentEvents());
+  attempt(res, 200, eventController.getCurrentEvents);
 });
 
 eventRouter.get("/past", async (req: Request, res: Response) => {
   // #swagger.tags = ['Events']
-  attempt(res, 200, () => eventController.getPastEvents());
+  attempt(res, 200, eventController.getPastEvents);
 });
 
 eventRouter.get("/:eventid", async (req: Request, res: Response) => {

--- a/backend/src/events/views.ts
+++ b/backend/src/events/views.ts
@@ -22,7 +22,7 @@ eventRouter.put("/:eventID", async (req: Request, res: Response) => {
   );
 });
 
-eventRouter.delete("/delete/:eventID", async (req: Request, res: Response) => {
+eventRouter.delete("/:eventID", async (req: Request, res: Response) => {
   // #swagger.tags = ['Events']
   attempt(res, 200, () => eventController.deleteEvent(req.params.eventID));
 });
@@ -58,7 +58,7 @@ eventRouter.get("/:eventid/attendees", async (req: Request, res: Response) => {
 });
 
 eventRouter.post(
-  "/:eventid/:attendeeid",
+  "/:eventid/attendees/:attendeeid",
   async (req: Request, res: Response) => {
     // #swagger.tags = ['Events']
     attempt(res, 200, () =>

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -4,12 +4,16 @@ import userRouter from "./users/views";
 import eventRouter from "./events/views";
 import swaggerUI from "swagger-ui-express";
 import spec from "../api-spec.json";
+import cors from "cors";
 
 const app: Application = express();
 
 // Middleware to parse json request bodies
 app.use(bodyParser.json());
 app.use("/api-docs", swaggerUI.serve, swaggerUI.setup(spec));
+
+// Middleware to allow cross-origin requests
+app.use(cors());
 
 /**
  * Sub-routers for our main router, we should have one sub-router per "entity" in the application

--- a/backend/src/users/views.ts
+++ b/backend/src/users/views.ts
@@ -22,15 +22,15 @@ userRouter.post("/", async (req: Request, res: Response) => {
   );
 });
 
-userRouter.delete("/:userID", async (req: Request, res: Response) => {
+userRouter.delete("/:userid", async (req: Request, res: Response) => {
   // #swagger.tags = ['Users']
-  attempt(res, 200, () => userController.deleteUser(req.params.userID));
+  attempt(res, 200, () => userController.deleteUser(req.params.userid));
 });
 
-userRouter.put("/:userID", async (req: Request, res: Response) => {
+userRouter.put("/:userid", async (req: Request, res: Response) => {
   // #swagger.tags = ['Users']
   attempt(res, 200, () =>
-    userController.updateUser(req.params.userID, req.body)
+    userController.updateUser(req.params.userid, req.body)
   );
 });
 
@@ -67,41 +67,41 @@ userRouter.get("/sorting", async (req: Request, res: Response) => {
   attempt(res, 200, () => userController.getUsersSorted(req));
 });
 
-userRouter.get("/:userID/profile", async (req: Request, res: Response) => {
+userRouter.get("/:userid/profile", async (req: Request, res: Response) => {
   // #swagger.tags = ['Users']
-  attempt(res, 200, () => userController.getUserProfile(req.params.userID));
+  attempt(res, 200, () => userController.getUserProfile(req.params.userid));
 });
 
-userRouter.get("/:userID/role", async (req: Request, res: Response) => {
+userRouter.get("/:userid/role", async (req: Request, res: Response) => {
   // #swagger.tags = ['Users']
-  attempt(res, 200, () => userController.getUserRole(req.params.userID));
+  attempt(res, 200, () => userController.getUserRole(req.params.userid));
 });
 
-userRouter.get("/:userID/preferences", async (req: Request, res: Response) => {
+userRouter.get("/:userid/preferences", async (req: Request, res: Response) => {
   // #swagger.tags = ['Users']
-  attempt(res, 200, () => userController.getUserPreferences(req.params.userID));
+  attempt(res, 200, () => userController.getUserPreferences(req.params.userid));
 });
 
-userRouter.get("/:userID", async (req: Request, res: Response) => {
+userRouter.get("/:userid", async (req: Request, res: Response) => {
   // #swagger.tags = ['Users']
-  attempt(res, 200, () => userController.getUserByID(req.params.userID));
+  attempt(res, 200, () => userController.getUserByID(req.params.userid));
 });
 
-userRouter.get("/:userID/created", async (req: Request, res: Response) => {
+userRouter.get("/:userid/created", async (req: Request, res: Response) => {
   // #swagger.tags = ['Users']
-  attempt(res, 200, () => userController.getCreatedEvents(req.params.userID));
+  attempt(res, 200, () => userController.getCreatedEvents(req.params.userid));
 });
 
-userRouter.get("/:userID/registered", async (req: Request, res: Response) => {
+userRouter.get("/:userid/registered", async (req: Request, res: Response) => {
   // #swagger.tags = ['Users']
   attempt(res, 200, () =>
-    userController.getRegisteredEvents(req.params.userID)
+    userController.getRegisteredEvents(req.params.userid)
   );
 });
 
-userRouter.get("/:userID/hours", async (req: Request, res: Response) => {
+userRouter.get("/:userid/hours", async (req: Request, res: Response) => {
   // #swagger.tags = ['Users']
-  attempt(res, 200, () => userController.getHours(req.params.userID));
+  attempt(res, 200, () => userController.getHours(req.params.userid));
 });
 
 userRouter.put("/:userid/profile", async (req: Request, res: Response) => {

--- a/backend/src/users/views.ts
+++ b/backend/src/users/views.ts
@@ -36,7 +36,7 @@ userRouter.put("/:userID", async (req: Request, res: Response) => {
 
 userRouter.get("/", async (req: Request, res: Response) => {
   // #swagger.tags = ['Users']
-  attempt(res, 200, () => userController.getAllUsers());
+  attempt(res, 200, userController.getAllUsers);
 });
 
 userRouter.get("/pagination", async (req: Request, res: Response) => {

--- a/backend/src/users/views.ts
+++ b/backend/src/users/views.ts
@@ -3,9 +3,7 @@ import userController from "./controllers";
 import { auth } from "../middleware/auth";
 const userRouter = Router();
 
-import { errorJson, successJson } from "../utils/jsonResponses";
-
-/** User Specific Routes */
+import { attempt } from "../utils/helpers";
 
 // No provision for auth in test environment for now
 if (process.env.NODE_ENV !== "test") {
@@ -14,229 +12,136 @@ if (process.env.NODE_ENV !== "test") {
 
 userRouter.post("/", async (req: Request, res: Response) => {
   // #swagger.tags = ['Users']
-  try {
-    res
-      .status(201)
-      // We expect an array of two elements, the first being the firebase user, the second being the user in the database
-      // TODO: Set Custom claims as required.
-      .send(
-        await userController.createUser(
-          req.body,
-          req.body.profile,
-          req.body.preferences,
-          req.body.permissions
-        )
-      );
-  } catch (error) {
-    console.log(error);
-    res.status(500).send(errorJson(error));
-  }
+  attempt(res, 201, () =>
+    userController.createUser(
+      req.body,
+      req.body.profile,
+      req.body.preferences,
+      req.body.permissions
+    )
+  );
 });
 
 userRouter.delete("/:userID", async (req: Request, res: Response) => {
   // #swagger.tags = ['Users']
-  try {
-    res.status(200).send(await userController.deleteUser(req.params.userID));
-  } catch (error) {
-    res.status(500).send(errorJson(error));
-  }
+  attempt(res, 200, () => userController.deleteUser(req.params.userID));
 });
 
 userRouter.put("/:userID", async (req: Request, res: Response) => {
   // #swagger.tags = ['Users']
-  try {
-    res
-      .status(200)
-      .send(await userController.updateUser(req.params.userID, req.body));
-  } catch (error) {
-    res.status(500).send(errorJson(error));
-  }
+  attempt(res, 200, () =>
+    userController.updateUser(req.params.userID, req.body)
+  );
 });
 
 userRouter.get("/", async (req: Request, res: Response) => {
   // #swagger.tags = ['Users']
-  try {
-    res.status(200).send(await userController.getAllUsers());
-  } catch (error) {
-    res.status(500).send(errorJson(error));
-  }
+  attempt(res, 200, () => userController.getAllUsers());
 });
 
 userRouter.get("/pagination", async (req: Request, res: Response) => {
   // #swagger.tags = ['Users']
-  try {
-    res.status(200).send(await userController.getUsersPaginated(req));
-  } catch (error) {
-    res.status(500).send(errorJson(error));
-  }
+  attempt(res, 200, () => userController.getUsersPaginated(req));
 });
 
 userRouter.get("/search", async (req: Request, res: Response) => {
   // #swagger.tags = ['Users']
   const { email, firstName, lastName, role, status, hours, nickname } =
     req.body;
-  try {
-    res
-      .status(200)
-      .send(
-        await userController.getSearchedUser(
-          req,
-          email,
-          firstName,
-          lastName,
-          role,
-          status,
-          hours,
-          nickname
-        )
-      );
-  } catch (error) {
-    res.status(500).send(errorJson(error));
-  }
+  attempt(res, 200, () =>
+    userController.getSearchedUser(
+      req,
+      email,
+      firstName,
+      lastName,
+      role,
+      status,
+      hours,
+      nickname
+    )
+  );
 });
 
 userRouter.get("/sorting", async (req: Request, res: Response) => {
   // #swagger.tags = ['Users']
-  try {
-    res.status(200).send(await userController.getUsersSorted(req));
-  } catch (error) {
-    res.status(500).send(errorJson(error));
-  }
+  attempt(res, 200, () => userController.getUsersSorted(req));
 });
 
 userRouter.get("/:userID/profile", async (req: Request, res: Response) => {
   // #swagger.tags = ['Users']
-  try {
-    res
-      .status(200)
-      .send(await userController.getUserProfile(req.params.userID));
-  } catch (error) {
-    res.status(500).send(errorJson(error));
-  }
+  attempt(res, 200, () => userController.getUserProfile(req.params.userID));
 });
 
 userRouter.get("/:userID/role", async (req: Request, res: Response) => {
   // #swagger.tags = ['Users']
-  try {
-    res.status(200).send(await userController.getUserRole(req.params.userID));
-  } catch (error) {
-    res.status(500).send(errorJson(error));
-  }
+  attempt(res, 200, () => userController.getUserRole(req.params.userID));
 });
 
 userRouter.get("/:userID/preferences", async (req: Request, res: Response) => {
   // #swagger.tags = ['Users']
-  try {
-    res
-      .status(200)
-      .send(await userController.getUserPreferences(req.params.userID));
-  } catch (error) {
-    res.status(500).send(errorJson(error));
-  }
+  attempt(res, 200, () => userController.getUserPreferences(req.params.userID));
 });
 
 userRouter.get("/:userID", async (req: Request, res: Response) => {
   // #swagger.tags = ['Users']
-  try {
-    res.status(200).send(await userController.getUserByID(req.params.userID));
-  } catch (error) {
-    res.status(500).send(errorJson(error));
-  }
+  attempt(res, 200, () => userController.getUserByID(req.params.userID));
 });
 
 userRouter.get("/:userID/created", async (req: Request, res: Response) => {
   // #swagger.tags = ['Users']
-  try {
-    res
-      .status(200)
-      .send(await userController.getCreatedEvents(req.params.userID));
-  } catch (error) {
-    res.status(500).send(errorJson(error));
-  }
+  attempt(res, 200, () => userController.getCreatedEvents(req.params.userID));
 });
 
 userRouter.get("/:userID/registered", async (req: Request, res: Response) => {
   // #swagger.tags = ['Users']
-  try {
-    res
-      .status(200)
-      .send(await userController.getRegisteredEvents(req.params.userID));
-  } catch (error) {
-    res.status(500).send(errorJson(error));
-  }
+  attempt(res, 200, () =>
+    userController.getRegisteredEvents(req.params.userID)
+  );
 });
 
 userRouter.get("/:userID/hours", async (req: Request, res: Response) => {
   // #swagger.tags = ['Users']
-  try {
-    res.status(200).send(await userController.getHours(req.params.userID));
-  } catch (error) {
-    res.status(500).send(errorJson(error));
-  }
+  attempt(res, 200, () => userController.getHours(req.params.userID));
 });
 
 userRouter.put("/:userid/profile", async (req: Request, res: Response) => {
   // #swagger.tags = ['Users']
-  try {
-    res
-      .status(200)
-      .send(await userController.editProfile(req.params.userid, req.body));
-  } catch (error) {
-    res.status(500).send(errorJson(error));
-  }
+  attempt(res, 200, () =>
+    userController.editProfile(req.params.userid, req.body)
+  );
 });
 
 userRouter.put("/:userid/preferences", async (req: Request, res: Response) => {
   // #swagger.tags = ['Users']
-  try {
-    res
-      .status(200)
-      .send(await userController.editPreferences(req.params.userid, req.body));
-  } catch (error) {
-    res.status(500).send(errorJson(error));
-  }
+  attempt(res, 200, () =>
+    userController.editPreferences(req.params.userid, req.body)
+  );
 });
 
 userRouter.patch(
   "/:userid/status/:status",
   async (req: Request, res: Response) => {
     // #swagger.tags = ['Users']
-    try {
-      res
-        .status(200)
-        .send(
-          await userController.editStatus(req.params.userid, req.params.status)
-        );
-    } catch (error) {
-      res.status(500).send(errorJson(error));
-    }
+    attempt(res, 200, () =>
+      userController.editStatus(req.params.userid, req.params.status)
+    );
   }
 );
 
 userRouter.patch("/:userid/role/:role", async (req: Request, res: Response) => {
   // #swagger.tags = ['Users']
-  try {
-    res
-      .status(200)
-      .send(await userController.editRole(req.params.userid, req.params.role));
-  } catch (error) {
-    res.status(500).send(errorJson(error));
-  }
+  attempt(res, 200, () =>
+    userController.editRole(req.params.userid, req.params.role)
+  );
 });
 
 userRouter.patch(
   "/:userid/hours/:hours",
   async (req: Request, res: Response) => {
     // #swagger.tags = ['Users']
-    try {
-      res
-        .status(200)
-        .send(
-          await userController.editHours(req.params.userid, req.params.hours)
-        );
-    } catch (error) {
-      res.status(500).send(errorJson(error));
-    }
+    attempt(res, 200, () =>
+      userController.editHours(req.params.userid, req.params.hours)
+    );
   }
 );
 

--- a/backend/src/utils/helpers.ts
+++ b/backend/src/utils/helpers.ts
@@ -1,5 +1,5 @@
 import { Response } from "express";
-import { errorJson } from "./jsonResponses";
+import { errorJson, successJson } from "./jsonResponses";
 
 /**
  * Attempts the given controller and sends a success code or error code as necessary
@@ -12,7 +12,7 @@ export const attempt = async (
   controller: () => Promise<unknown>
 ) => {
   try {
-    res.status(successCode).send(await controller());
+    res.status(successCode).send(successJson(await controller()));
   } catch (error) {
     res.status(500).send(errorJson(error));
   }

--- a/backend/src/utils/helpers.ts
+++ b/backend/src/utils/helpers.ts
@@ -1,0 +1,19 @@
+import { Router, RequestHandler, Request, Response } from "express";
+import { errorJson, successJson } from "./jsonResponses";
+
+/**
+ * Attempts the given controller and sends a success code or error code as necessary
+ * @param successCode is the success code
+ * @param controller is the function called from the controller
+ */
+export const attempt = async (
+  res: Response,
+  successCode: number,
+  controller: () => Promise<any>
+) => {
+  try {
+    res.status(successCode).send(await controller());
+  } catch (error) {
+    res.status(500).send(errorJson(error));
+  }
+};

--- a/backend/src/utils/helpers.ts
+++ b/backend/src/utils/helpers.ts
@@ -1,5 +1,5 @@
-import { Router, RequestHandler, Request, Response } from "express";
-import { errorJson, successJson } from "./jsonResponses";
+import { Response } from "express";
+import { errorJson } from "./jsonResponses";
 
 /**
  * Attempts the given controller and sends a success code or error code as necessary
@@ -9,7 +9,7 @@ import { errorJson, successJson } from "./jsonResponses";
 export const attempt = async (
   res: Response,
   successCode: number,
-  controller: () => Promise<any>
+  controller: () => Promise<unknown>
 ) => {
   try {
     res.status(successCode).send(await controller());

--- a/backend/tests/events.test.ts
+++ b/backend/tests/events.test.ts
@@ -170,10 +170,10 @@ describe("Testing POST /events/:eventid/:attendeeid", () => {
     const attendeeid_1 = users.body.data[1].id;
     const attendeeid_2 = users.body.data[2].id;
     const response = await request(app).post(
-      "/events/" + eventid + "/" + attendeeid_1
+      "/events/" + eventid + "/attendees/" + attendeeid_1
     );
     const response_too = await request(app).post(
-      "/events/" + eventid + "/" + attendeeid_2
+      "/events/" + eventid + "/attendees/" + attendeeid_2
     );
     expect(response.status).toBe(200);
     expect(response_too.status).toBe(200);
@@ -233,7 +233,7 @@ describe("Testing DELETE event", () => {
   test("Delete valid event", async () => {
     const events = await request(app).get("/events");
     const eventid = events.body.data[2].id;
-    const response = await request(app).delete("/events/delete/" + eventid);
+    const response = await request(app).delete("/events/" + eventid);
     expect(response.status).toBe(200);
     const deletedEvent = await request(app).get("/events/" + eventid);
     expect(deletedEvent.body.data).toEqual(null);
@@ -241,7 +241,7 @@ describe("Testing DELETE event", () => {
 
   test("Delete invalid event", async () => {
     const eventid = -1;
-    const response = await request(app).delete("/events/delete/" + eventid);
+    const response = await request(app).delete("/events/" + eventid);
     expect(response.status).toBe(500);
   });
 });

--- a/backend/tests/events.test.ts
+++ b/backend/tests/events.test.ts
@@ -42,9 +42,9 @@ describe("Testing POST /events/:eventID", () => {
     };
     const users = await request(app).get("/users");
     const response = await request(app)
-      .post(`/events/${users.body[1].id}`)
+      .post(`/events/${users.body.data[1].id}`)
       .send(event);
-    const data = response.body;
+    const data = response.body.data;
     expect(data.name).toBe("Cool Event");
     expect(data.location).toBe("Hack Hall");
 
@@ -55,7 +55,7 @@ describe("Testing POST /events/:eventID", () => {
     const event = {};
     const users = await request(app).get("/users");
     const response = await request(app)
-      .post(`/events/${users.body[0].id}`)
+      .post(`/events/${users.body.data[0].id}`)
       .send(event);
     expect(response.status).toBe(500);
   });
@@ -67,11 +67,11 @@ describe("Testing PUT /events/:eventid", () => {
       name: "New Event",
     };
     const events = await request(app).get("/events");
-    const eventid = events.body[1].id;
+    const eventid = events.body.data[1].id;
     const response = await request(app)
       .put("/events/" + eventid)
       .send(event);
-    const data = response.body;
+    const data = response.body.data;
     expect(data.name).toBe("New Event");
     expect(response.status).toBe(200);
   });
@@ -80,7 +80,7 @@ describe("Testing PUT /events/:eventid", () => {
 describe("Testing GET /events/:eventid", () => {
   test("Get existing event", async () => {
     const events = await request(app).get("/events");
-    const eventid = events.body[1].id;
+    const eventid = events.body.data[1].id;
     const response = await request(app).get("/events/" + eventid);
     expect(response.status).toBe(200);
   });
@@ -88,14 +88,14 @@ describe("Testing GET /events/:eventid", () => {
   test("Get non-existing event", async () => {
     const eventid = -1;
     const response = await request(app).get("/events/" + eventid);
-    expect(response.body).toEqual({});
+    expect(response.body.data).toEqual(null);
   });
 });
 
 describe("Testing GET /events/:eventid/attendees", () => {
   test("Get attendees for existing event", async () => {
     const events = await request(app).get("/events");
-    const eventid = events.body[0].id;
+    const eventid = events.body.data[0].id;
     const response = await request(app).get(
       "/events/" + eventid + "/attendees"
     );
@@ -107,26 +107,26 @@ describe("Testing GET /events/:eventid/attendees", () => {
     const response = await request(app).get(
       "/events/" + eventid + "/attendees"
     );
-    expect(response.body.length).toBe(0);
+    expect(response.body.data.length).toBe(0);
   });
 });
 
 describe("Testing PATCH /events/:eventid/status/:status", () => {
   test("Update event status to active", async () => {
     const events = await request(app).get("/events");
-    const eventid = events.body[0].id;
+    const eventid = events.body.data[0].id;
     const status = "ACTIVE";
     const response = await request(app).patch(
       `/events/${eventid}/status/${status}`
     );
-    const data = response.body;
+    const data = response.body.data;
     expect(response.status).toBe(200);
     expect(data.status).toBe("ACTIVE");
   });
 
   test("Event status invalid", async () => {
     const events = await request(app).get("/events");
-    const eventid = events.body[0].id;
+    const eventid = events.body.data[0].id;
     const status = "COMPLETE";
     const response = await request(app).patch(
       "/events/" + eventid + "/status/" + status
@@ -138,23 +138,23 @@ describe("Testing PATCH /events/:eventid/status/:status", () => {
 describe("Testing PATCH /events/:eventid/owner/:ownerid", () => {
   test("Change current owner", async () => {
     const events = await request(app).get("/events");
-    const eventid = events.body[1].id;
-    const event = events.body[1];
+    const eventid = events.body.data[1].id;
+    const event = events.body.data[1];
     const users = await request(app).get("/users");
-    const ownerid = users.body[1].id;
+    const ownerid = users.body.data[1].id;
     const response = await request(app).patch(
       "/events/" + eventid + "/owner/" + ownerid
     );
-    const data = response.body;
+    const data = response.body.data;
     expect(response.status).toBe(200);
-    expect(data.ownerId).toBe(users.body[1].id);
+    expect(data.ownerId).toBe(users.body.data[1].id);
   });
 
   test("Change current owner to invalid", async () => {
     const events = await request(app).get("/events");
-    const eventid = events.body[1].id;
+    const eventid = events.body.data[1].id;
     const users = await request(app).get("/users");
-    const ownerid = users.body[-1];
+    const ownerid = users.body.data[-1];
     const response = await request(app).patch(
       "/events/" + eventid + "/owner/" + ownerid
     );
@@ -166,9 +166,9 @@ describe("Testing POST /events/:eventid/:attendeeid", () => {
   test("Add attendee for existing event", async () => {
     const events = await request(app).get("/events");
     const users = await request(app).get("/users");
-    const eventid = events.body[1].id;
-    const attendeeid_1 = users.body[1].id;
-    const attendeeid_2 = users.body[2].id;
+    const eventid = events.body.data[1].id;
+    const attendeeid_1 = users.body.data[1].id;
+    const attendeeid_2 = users.body.data[2].id;
     const response = await request(app).post(
       "/events/" + eventid + "/" + attendeeid_1
     );
@@ -184,19 +184,19 @@ describe("Testing PATCH /events/:eventid/attendees/:attendeeid/confirm", () => {
   test("Update attendee as showed up", async () => {
     const events = await request(app).get("/events");
     const attendees = await request(app).get("/users");
-    const eventid = events.body[1].id;
-    const attendeeid = attendees.body[1].id;
+    const eventid = events.body.data[1].id;
+    const attendeeid = attendees.body.data[1].id;
     const response = await request(app).patch(
       "/events/" + eventid + "/attendees/" + attendeeid + "/confirm"
     );
-    const data = response.body;
+    const data = response.body.data;
     expect(data.showedUp).toBe(true);
     expect(response.status).toBe(200);
   });
 
   test("Invalid update attendee as showed up", async () => {
     const attendees = await request(app).get("/users");
-    const attendeeid = attendees.body[0].id;
+    const attendeeid = attendees.body.data[0].id;
     const response = await request(app).patch(
       "/events/" + -1 + "/attendees/" + attendeeid + "/confirm"
     );
@@ -208,8 +208,8 @@ describe("Testing DELETE /events/:eventid/attendees/:attendeeid", () => {
   test("Delete an attendee", async () => {
     const events = await request(app).get("/events");
     const attendees = await request(app).get("/users");
-    const eventid = events.body[1].id;
-    const attendeeid = attendees.body[1].id;
+    const eventid = events.body.data[1].id;
+    const attendeeid = attendees.body.data[1].id;
     const response = await request(app).delete(
       "/events/" + eventid + "/attendees/" + attendeeid
     );
@@ -219,8 +219,8 @@ describe("Testing DELETE /events/:eventid/attendees/:attendeeid", () => {
 
   test("Delete an invalid attendee", async () => {
     const events = await request(app).get("/events");
-    const eventid = events.body[1].id;
-    const attendeeid = events.body[1].userID;
+    const eventid = events.body.data[1].id;
+    const attendeeid = events.body.data[1].userID;
     const response = await request(app).delete(
       "/events/" + eventid + "/attendees/" + attendeeid
     );
@@ -232,11 +232,11 @@ describe("Testing DELETE /events/:eventid/attendees/:attendeeid", () => {
 describe("Testing DELETE event", () => {
   test("Delete valid event", async () => {
     const events = await request(app).get("/events");
-    const eventid = events.body[2].id;
+    const eventid = events.body.data[2].id;
     const response = await request(app).delete("/events/delete/" + eventid);
     expect(response.status).toBe(200);
     const deletedEvent = await request(app).get("/events/" + eventid);
-    expect(deletedEvent.body).toEqual({});
+    expect(deletedEvent.body.data).toEqual(null);
   });
 
   test("Delete invalid event", async () => {

--- a/backend/tests/users.test.ts
+++ b/backend/tests/users.test.ts
@@ -458,7 +458,7 @@ describe("Testing /users/:userID/hours", () => {
 describe("Testing GET /users/pagination", () => {
   test("Get 2 users after the second use", async () => {
     const users = await request(app).get("/users");
-    const userid = users.body.data[1].id;
+    const userid = users.body.data[2].id;
     const response = await request(app).get(
       "/users/pagination?limit=2&after=" + userid
     );

--- a/backend/tests/users.test.ts
+++ b/backend/tests/users.test.ts
@@ -482,7 +482,7 @@ describe("Testing GET /users/pagination", () => {
 describe("Testing DELETE /users/:userid", () => {
   test("Delete valid user", async () => {
     const users = await request(app).get("/users");
-    const userid = users.body.data[1].id;
+    const userid = users.body.data[0].id;
     const response = await request(app).delete("/users/" + userid);
     expect(response.status).toBe(200);
 

--- a/backend/tests/users.test.ts
+++ b/backend/tests/users.test.ts
@@ -17,7 +17,7 @@ describe("Testing POST /users", () => {
       role: "ADMIN",
     };
     const response = await request(app).post("/users").send(user);
-    const data = response.body;
+    const data = response.body.data;
     expect(data.email).toBe("desi2@gmail.com");
     expect(data.role).toBe("ADMIN");
 
@@ -39,12 +39,12 @@ describe("Testing PUT /users/:userid", () => {
 
     // This is temporary till we create an endpoint to get a specific user
     const users = await request(app).get("/users");
-    const userid = users.body[1].id;
+    const userid = users.body.data[1].id;
 
     const response = await request(app)
       .put("/users/" + userid)
       .send(user);
-    const data = response.body;
+    const data = response.body.data;
     expect(data.email).toBe("asu284@cornell.edu");
     expect(response.status).toBe(200);
   });
@@ -66,7 +66,7 @@ describe("Testing PUT /users/:userid/profile", () => {
     };
 
     const createdUser = await request(app).post("/users").send(user);
-    const userid = createdUser.body.id;
+    const userid = createdUser.body.data.id;
 
     const editProfile = {
       firstName: "Arizona2",
@@ -77,7 +77,7 @@ describe("Testing PUT /users/:userid/profile", () => {
       .put("/users/" + userid + "/profile")
       .send(editProfile);
 
-    const data = response.body;
+    const data = response.body.data;
     expect(data.profile.firstName).toBe("Arizona2");
     expect(data.profile.lastName).toBe("Tea2");
     expect(data.profile.nickname).toBe("99cents");
@@ -96,7 +96,7 @@ describe("Testing PUT /users/:userid/preferences", () => {
 
     const createdUser = await request(app).post("/users").send(user);
 
-    const userid = createdUser.body.id;
+    const userid = createdUser.body.data.id;
 
     const editPreferences = {
       sendEmailNotification: false,
@@ -107,7 +107,7 @@ describe("Testing PUT /users/:userid/preferences", () => {
       .put("/users/" + userid + "/preferences")
       .send(editPreferences);
 
-    const data = response.body;
+    const data = response.body.data;
 
     expect(data.preferences.sendEmailNotification).toBe(false);
     expect(data.preferences.sendPromotions).toBe(true);
@@ -120,11 +120,11 @@ describe("Testing PATCH /users/:userid/status/:status", () => {
   test("PATCH edit a user's role with an existing role", async () => {
     // This is temporary till we create an endpoint to get a specific user
     const users = await request(app).get("/users");
-    const userid = users.body[1].id;
+    const userid = users.body.data[1].id;
     const response = await request(app).patch(
       "/users/" + userid + "/role" + "/SUPERVISOR"
     );
-    const data = response.body;
+    const data = response.body.data;
     expect(data.role).toBe("SUPERVISOR");
     expect(response.status).toBe(200);
   });
@@ -134,11 +134,11 @@ describe("Testing PATCH /users/:userid/hours/:hours", () => {
   test("PATCH edit a user's hours with an existing hours", async () => {
     // This is temporary till we create an endpoint to get a specific user
     const users = await request(app).get("/users");
-    const userid = users.body[1].id;
+    const userid = users.body.data[1].id;
     const response = await request(app).patch(
       "/users/" + userid + "/hours" + "/10"
     );
-    const data = response.body;
+    const data = response.body.data;
     expect(data.hours).toBe(10);
     expect(response.status).toBe(200);
   });
@@ -152,7 +152,7 @@ describe("Testing /users/search", () => {
 
   test("GET users with firstName=Alice", async () => {
     const response = await request(app).get("/users/search?firstName=Alice");
-    const data = response.body;
+    const data = response.body.data;
     for (let i = 0; i < data.length; i++) {
       expect(data[i].profile.firstName).toBe("Alice");
     }
@@ -161,7 +161,7 @@ describe("Testing /users/search", () => {
 
   test("GET users with role=ADMIN", async () => {
     const response = await request(app).get("/users/search?role=ADMIN");
-    const data = response.body;
+    const data = response.body.data;
     for (let i = 0; i < data.length; i++) {
       expect(data[i].role).toBe("ADMIN");
     }
@@ -170,7 +170,7 @@ describe("Testing /users/search", () => {
 
   test("GET users with hours=0", async () => {
     const response = await request(app).get("/users/search?hours=0");
-    const data = response.body;
+    const data = response.body.data;
     for (let i = 0; i < data.length; i++) {
       expect(data[i].hours).toBe(0);
     }
@@ -182,7 +182,7 @@ describe("Testing /users/search", () => {
     const response = await request(app).get(
       "/users/search?hours=0&firstName=Alice"
     );
-    const data = response.body;
+    const data = response.body.data;
 
     for (let i = 0; i < data.length; i++) {
       expect(data[i].hours).toBe(0);
@@ -195,7 +195,7 @@ describe("Testing /users/search", () => {
     const response = await request(app).get(
       "/users/search?hours=0&firstName=Alice&status=ACTIVE"
     );
-    const data = response.body;
+    const data = response.body.data;
 
     for (let i = 0; i < data.length; i++) {
       expect(data[i].hours).toBe(0);
@@ -210,7 +210,7 @@ describe("Testing GET /users/:userid/profile", () => {
   test("GET user's profile", async () => {
     // This is temporary till we create an endpoint to get a specific user
     const users = await request(app).get("/users");
-    const userid = users.body[0].id;
+    const userid = users.body.data[0].id;
 
     const response = await request(app).get("/users/" + userid + "/profile");
     expect(response.status).toBe(200);
@@ -222,7 +222,7 @@ describe("Testing GET /users/:userid/profile", () => {
     };
 
     const users = await request(app).get("/users");
-    const userid = users.body[1].id;
+    const userid = users.body.data[1].id;
 
     const response = await request(app).get("/users/" + userid + "/profile");
     expect(response.status).toBe(200);
@@ -232,7 +232,7 @@ describe("Testing GET /users/:userid/profile", () => {
 describe("Testing GET /users/:userid/role", () => {
   test("GET supervisor user's role", async () => {
     const users = await request(app).get("/users");
-    const userid = users.body[1].id;
+    const userid = users.body.data[1].id;
 
     const response = await request(app).get("/users/" + userid + "/role");
     expect(response.status).toBe(200);
@@ -240,7 +240,7 @@ describe("Testing GET /users/:userid/role", () => {
 
   test("GET user's default role", async () => {
     const users = await request(app).get("/users");
-    const userid = users.body[0].id;
+    const userid = users.body.data[0].id;
 
     const response = await request(app).get("/users/" + userid + "/role");
     expect(response.status).toBe(200);
@@ -250,7 +250,7 @@ describe("Testing GET /users/:userid/role", () => {
 describe("Testing GET /users/:userid/preferences", () => {
   test("GET user's default preferences", async () => {
     const users = await request(app).get("/users");
-    const userid = users.body[0].id;
+    const userid = users.body.data[0].id;
 
     const response = await request(app).get(
       "/users/" + userid + "/preferences"
@@ -260,12 +260,12 @@ describe("Testing GET /users/:userid/preferences", () => {
 
   test("GET user's non-default preferences", async () => {
     const users = await request(app).get("/users");
-    const userid = users.body[1].id;
+    const userid = users.body.data[1].id;
 
     const response = await request(app).get(
       "/users/" + userid + "/preferences"
     );
-    const data = response.body;
+    const data = response.body.data;
     expect(response.status).toBe(200);
   });
 });
@@ -274,7 +274,7 @@ describe("Testing GET /users/:userid/profile", () => {
   test("GET user's profile", async () => {
     // This is temporary till we create an endpoint to get a specific user
     const users = await request(app).get("/users");
-    const userid = users.body[0].id;
+    const userid = users.body.data[0].id;
 
     const response = await request(app).get("/users/" + userid + "/profile");
     expect(response.status).toBe(200);
@@ -282,7 +282,7 @@ describe("Testing GET /users/:userid/profile", () => {
 
   test("GET 2nd user's profile", async () => {
     const users = await request(app).get("/users");
-    const userid = users.body[1].id;
+    const userid = users.body.data[1].id;
 
     const response = await request(app).get("/users/" + userid + "/profile");
     expect(response.status).toBe(200);
@@ -292,7 +292,7 @@ describe("Testing GET /users/:userid/profile", () => {
 describe("Testing GET /users/:userid/role", () => {
   test("GET supervisor user's role", async () => {
     const users = await request(app).get("/users");
-    const userid = users.body[1].id;
+    const userid = users.body.data[1].id;
 
     const response = await request(app).get("/users/" + userid + "/role");
     expect(response.status).toBe(200);
@@ -300,7 +300,7 @@ describe("Testing GET /users/:userid/role", () => {
 
   test("GET user's default role", async () => {
     const users = await request(app).get("/users");
-    const userid = users.body[0].id;
+    const userid = users.body.data[0].id;
 
     const response = await request(app).get("/users/" + userid + "/role");
     expect(response.status).toBe(200);
@@ -310,7 +310,7 @@ describe("Testing GET /users/:userid/role", () => {
 describe("Testing GET /users/:userid/preferences", () => {
   test("GET user's default preferences", async () => {
     const users = await request(app).get("/users");
-    const userid = users.body[0].id;
+    const userid = users.body.data[0].id;
 
     const response = await request(app).get(
       "/users/" + userid + "/preferences"
@@ -320,7 +320,7 @@ describe("Testing GET /users/:userid/preferences", () => {
 
   test("GET user's non-default preferences", async () => {
     const users = await request(app).get("/users");
-    const userid = users.body[1].id;
+    const userid = users.body.data[1].id;
 
     const response = await request(app).get(
       "/users/" + userid + "/preferences"
@@ -336,10 +336,10 @@ describe("Testing /users/:userID", () => {
     };
 
     const POSTresponse = await request(app).post("/users").send(user);
-    const userID = POSTresponse.body.id;
+    const userID = POSTresponse.body.data.id;
 
     const GETresponse = await request(app).get("/users/" + userID);
-    const data = GETresponse.body;
+    const data = GETresponse.body.data;
     expect(GETresponse.status).toBe(200);
     expect(data.email).toBe("test@gmail.com");
   });
@@ -347,7 +347,7 @@ describe("Testing /users/:userID", () => {
   test("GET null user", async () => {
     const response = await request(app).get("/users/z");
     expect(response.status).toBe(200);
-    expect(response.body).toEqual({});
+    expect(response.body.data).toEqual(null);
   });
 });
 
@@ -356,7 +356,7 @@ describe("Testing /users/sorting/", () => {
     const response = await request(app).get(
       "/users/sorting?sort=firstName:asc"
     );
-    const data = response.body;
+    const data = response.body.data;
     expect(data[0].profile.firstName >= data[1].profile.firstName);
     expect(response.status).toBe(200);
   });
@@ -365,7 +365,7 @@ describe("Testing /users/sorting/", () => {
     const response = await request(app).get(
       "/users/sorting?sort=firstName:desc"
     );
-    const data = response.body;
+    const data = response.body.data;
     expect(data[0].profile == null); //any null profiles should show up first
     expect(data[0].profile.firstName <= data[1].profile.firstName);
     expect(response.status).toBe(200);
@@ -375,7 +375,7 @@ describe("Testing /users/sorting/", () => {
     const response = await request(app).get(
       "/users/sorting?sort=firstName:desc"
     );
-    const data = response.body;
+    const data = response.body.data;
     expect(data[0].profile == null); //any null profiles should show up first
     expect(data[0].profile.lastName <= data[1].profile.lastName);
     expect(response.status).toBe(200);
@@ -383,14 +383,14 @@ describe("Testing /users/sorting/", () => {
 
   test("GET users sorted by hours in descending order", async () => {
     const response = await request(app).get("/users/sorting?sort=hours:desc");
-    const data = response.body;
+    const data = response.body.data;
     expect(data[0].hours <= data[1].hours);
     expect(response.status).toBe(200);
   });
 
   test("GET users sorted by email in ascending order", async () => {
     const response = await request(app).get("/users/sorting?sort=email:asc");
-    const data = response.body;
+    const data = response.body.data;
     expect(data[0].email <= data[1].email);
     expect(response.status).toBe(200);
   });
@@ -401,17 +401,17 @@ describe("Testing /users/:userID/created", () => {
     const POSTresponse = await request(app).get(
       "/users/search?firstName=Prisma"
     );
-    const userID = POSTresponse.body[0].id;
+    const userID = POSTresponse.body.data[0].id;
 
     const response = await request(app).get("/users/" + userID + "/created");
-    const data = response.body;
+    const data = response.body.data;
     expect(response.status).toBe(200);
   });
 
   test("GET createdEvents of null user", async () => {
     const response = await request(app).get("/users/z/created");
     expect(response.status).toBe(200);
-    expect(response.body).toEqual({});
+    expect(response.body.data).toEqual(null);
   });
 });
 
@@ -420,7 +420,7 @@ describe("Testing /users/:userID/registered", () => {
     const POSTresponse = await request(app).get(
       "/users/search?firstName=Alice"
     );
-    const userID = POSTresponse.body[0].id;
+    const userID = POSTresponse.body.data[0].id;
 
     const GETresponse = await request(app).get(
       "/users/" + userID + "/registered"
@@ -431,7 +431,7 @@ describe("Testing /users/:userID/registered", () => {
   test("GET registeredEvents of null user", async () => {
     const response = await request(app).get("/users/z/registered");
     expect(response.status).toBe(200);
-    expect(response.body).toEqual({});
+    expect(response.body.data).toEqual(null);
   });
 });
 
@@ -440,10 +440,10 @@ describe("Testing /users/:userID/hours", () => {
     const POSTresponse = await request(app).get(
       "/users/search?firstName=Prisma"
     );
-    const userID = POSTresponse.body[0].id;
+    const userID = POSTresponse.body.data[0].id;
 
     const GETresponse = await request(app).get("/users/" + userID + "/hours");
-    const data = GETresponse.body;
+    const data = GETresponse.body.data;
     expect(GETresponse.status).toBe(200);
     expect(data.hours).toBe(0);
   });
@@ -451,18 +451,18 @@ describe("Testing /users/:userID/hours", () => {
   test("GET hours of null user", async () => {
     const response = await request(app).get("/users/z/hours");
     expect(response.status).toBe(200);
-    expect(response.body).toEqual({});
+    expect(response.body.data).toEqual(null);
   });
 });
 
 describe("Testing GET /users/pagination", () => {
   test("Get 2 users after the second use", async () => {
     const users = await request(app).get("/users");
-    const userid = users.body[1].id;
+    const userid = users.body.data[1].id;
     const response = await request(app).get(
       "/users/pagination?limit=2&after=" + userid
     );
-    const data = response.body;
+    const data = response.body.data;
     expect(response.status).toBe(200);
     expect(data.length).toBe(2);
   });
@@ -470,7 +470,7 @@ describe("Testing GET /users/pagination", () => {
   test("Get 10 users after the second use", async () => {
     // limit should be defaulted to 10
     const users = await request(app).get("/users");
-    const userid = users.body[2].id;
+    const userid = users.body.data[2].id;
     const response = await request(app).get(
       "/users/pagination?after=" + userid
     );
@@ -482,13 +482,13 @@ describe("Testing GET /users/pagination", () => {
 describe("Testing DELETE /users/:userid", () => {
   test("Delete valid user", async () => {
     const users = await request(app).get("/users");
-    const userid = users.body[0].id;
+    const userid = users.body.data[1].id;
     const response = await request(app).delete("/users/" + userid);
     expect(response.status).toBe(200);
 
     const getResponse = await request(app).get("/users/" + userid);
     expect(getResponse.status).toBe(200);
-    expect(getResponse.body).toEqual({});
+    expect(getResponse.body.data).toEqual(null);
   });
 
   test("Delete invalid user", async () => {

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -1638,6 +1638,13 @@
   resolved "https://registry.yarnpkg.com/@types/cookiejar/-/cookiejar-2.1.2.tgz#66ad9331f63fe8a3d3d9d8c6e3906dd10f6446e8"
   integrity sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==
 
+"@types/cors@^2.8.13":
+  version "2.8.13"
+  resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.13.tgz#b8ade22ba455a1b8cb3b5d3f35910fd204f84f94"
+  integrity sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/express-serve-static-core@^4.17.31":
   version "4.17.32"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.32.tgz#93dda387f5516af616d8d3f05f2c4c79d81e1b82"
@@ -2365,6 +2372,14 @@ cookiejar@^2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.4.tgz#ee669c1fea2cf42dc31585469d193fef0d65771b"
   integrity sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==
+
+cors@^2.8.5:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
+  integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
+  dependencies:
+    object-assign "^4"
+    vary "^1"
 
 create-require@^1.1.0:
   version "1.1.1"
@@ -4049,6 +4064,11 @@ npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
+object-assign@^4:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
+
 object-hash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-3.0.0.tgz#73f97f753e7baffc0e2cc9d6e079079744ac82e9"
@@ -4908,7 +4928,7 @@ v8-to-istanbul@^9.0.1:
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^1.6.0"
 
-vary@~1.1.2:
+vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -6,6 +6,7 @@ import styles from "@/styles/Home.module.css";
 import { Button, Grid, Stack } from "@mui/material";
 import { useAuth } from "@/utils/AuthContext";
 import Login from "@/components/Login";
+import { BASE_URL } from "@/utils/constants";
 
 const Home = () => {
   const { user, loading, error, signOutUser } = useAuth();
@@ -17,6 +18,18 @@ const Home = () => {
   if (!user) {
     return <Login />;
   }
+
+  // Temporary fetch request to test if the backend is running
+  useEffect(() => {
+    try{
+      // Note how BASE_URL is imported from a constants file and type casted to a string
+      const url = BASE_URL as string
+      fetch(url).then(data => console.log(data))
+    }catch(error){
+      console.log(error)
+    }
+  }, []);
+
 
   return (
     <>

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -21,15 +21,14 @@ const Home = () => {
 
   // Temporary fetch request to test if the backend is running
   useEffect(() => {
-    try{
+    try {
       // Note how BASE_URL is imported from a constants file and type casted to a string
-      const url = BASE_URL as string
-      fetch(url).then(data => console.log(data))
-    }catch(error){
-      console.log(error)
+      const url = BASE_URL as string;
+      fetch(url).then((data) => console.log(data));
+    } catch (error) {
+      console.log(error);
     }
   }, []);
-
 
   return (
     <>

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -1,3 +1,8 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body{
+  margin: 0;
+  padding: 0;
+}

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -2,7 +2,7 @@
 @tailwind components;
 @tailwind utilities;
 
-body{
+body {
   margin: 0;
   padding: 0;
 }

--- a/frontend/src/utils/constants.tsx
+++ b/frontend/src/utils/constants.tsx
@@ -1,0 +1,1 @@
+export const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;


### PR DESCRIPTION
## Summary

Create a new function `attempt` in `utils/helpers.ts` which acts as a wrapper for `users/views.ts` and `events/views.ts`. Rather than using a `try { ... } catch { ... }` block for every single controller, you can now simply do `attempt(() => function_name)`, making for much cleaner code.