### PR TITLE
Added navigation bar

### DIFF
--- a/frontend/src/components/molecules/NavBar.tsx
+++ b/frontend/src/components/molecules/NavBar.tsx
@@ -1,8 +1,60 @@
-import React from "react";
+import React from 'react';
+import { useState } from "react"; 
 
-/** A NavBar page */
 const NavBar = () => {
-  return <>Hello there</>;
+  const [menuOpen, setMenuOpen] = useState(false)
+
+  const handleNav = () => {
+    setMenuOpen(!menuOpen); 
+  }
+  return (
+    <>
+
+    <div className = "grid grid-cols-12">
+      <div className = "col-span-11 justify-between items-center px-8 py-6 col-span-1 bg-gray-300 font-mono text-4xl">LFBI
+      </div>
+      <div className = "space-y-2 bg-gray-300 object-center py-8 px-10">
+        <div className = "w-8 h-0.5 bg-black animate-pulse"></div>
+        <div className = "w-8 h-0.5 bg-black animate-pulse"></div>
+        <div className = "w-8 h-0.5 bg-black animate-pulse"></div>
+      </div>
+    </div>
+
+    {/* <button className = "bg-gray-300 hover:bg-gray-700 text-white font-bold py-4 px-4 rounded">LFB</button> */}
+    
+    </>
+  );
 };
 
 export default NavBar;
+
+// import React from 'react';
+// import { useState } from "react"; 
+
+// const NavBar = () => {
+//   const [menuOpen, setMenuOpen] = useState(false)
+
+//   const handleNav = () => {
+//     setMenuOpen(!menuOpen); 
+//   }
+//   return (
+//     <>
+//     <nav className="fixed w-full h-24 shadow-x1 bg-gray">
+//       <div className = "flex justify-between items-center h-full w-full px-4 2x1:px-16">
+//           <div> LFB</div>
+//           <div> Menu</div>
+//         </div>  
+//         <div onClick = {handleNav} className = "sm:hidden cursor-pointer pl-24"/>
+
+//         <div className ={
+//           menuOpen
+//           ? "fixed left-0 top-0 w-[65%] sm:hidden h-screen bg-[#ecf0f3] p-10 ease-in duration-500"
+//           : "fixed left-[- 100%] top-0 p-10 ease-in duration-500"
+//         }>
+//         </div>
+//     </nav>
+//     </>
+//   );
+// };
+
+// export default NavBar;

--- a/frontend/src/components/templates/WelcomeTemplate.tsx
+++ b/frontend/src/components/templates/WelcomeTemplate.tsx
@@ -1,8 +1,10 @@
 import React from "react";
+import NavBar from "../molecules/NavBar";
 
 /** A WelcomeTemplate page */
 const WelcomeTemplate = () => {
-  return <>Hello there</>;
+  return <>
+  <NavBar></NavBar></>;
 };
 
 export default WelcomeTemplate;

--- a/frontend/src/pages/login.tsx
+++ b/frontend/src/pages/login.tsx
@@ -1,8 +1,10 @@
 import React from "react";
+import WelcomeTemplate from "@/components/templates/WelcomeTemplate";
 
 /** A Login page */
 const Login = () => {
-  return <>Hello there</>;
+  return <>
+  <WelcomeTemplate /></>;
 };
 
 export default Login;


### PR DESCRIPTION
## Summary

Closes #42 
Implemented a navigation bar that includes the organization name in laptop view as well as the organization name in mobile view and a hamburger menu. 

## Testing

Steps: 
Run yarn run dev in frontend: 
<img width="242" alt="image" src="https://user-images.githubusercontent.com/66981728/233745023-560f7f3e-507c-4c00-9073-916ed4792451.png">

## Notes

The navigation bar stays consistently at the top of the browser, however there are currently no buttons to be clicked as featured in the design. 