### PR TITLE
Create pages for create event and edit event

### DIFF
--- a/frontend/src/components/templates/CenteredTemplate.tsx
+++ b/frontend/src/components/templates/CenteredTemplate.tsx
@@ -8,7 +8,7 @@ type CenteredTemplateProps = {
 
 const CenteredTemplate = ({ body }: CenteredTemplateProps) => {
   return (
-    <div className="flex flex-col h-screen">
+    <div className="h-screen">
       <NavBar />
       <div className="max-w-3xl mx-auto py-10 px-10">{body}</div>
     </div>

--- a/frontend/src/components/templates/CenteredTemplate.tsx
+++ b/frontend/src/components/templates/CenteredTemplate.tsx
@@ -10,9 +10,7 @@ const CenteredTemplate = ({ body }: CenteredTemplateProps) => {
   return (
     <div className="flex flex-col h-screen">
       <NavBar />
-      <div className="flex items-center justify-center">
-        <div className="w-full sm:px-32 sm:py-10 px-16 py-10">{body}</div>
-      </div>
+      <div className="max-w-3xl mx-auto py-10 px-10">{body}</div>
     </div>
   );
 };

--- a/frontend/src/components/templates/CenteredTemplate.tsx
+++ b/frontend/src/components/templates/CenteredTemplate.tsx
@@ -10,7 +10,7 @@ const CenteredTemplate = ({ body }: CenteredTemplateProps) => {
   return (
     <div className="flex flex-col h-screen">
       <NavBar />
-      <div className="flex items-center justify-center bg-white">
+      <div className="flex items-center justify-center">
         <div className="w-full sm:px-32 sm:py-10 px-16 py-10">{body}</div>
       </div>
     </div>

--- a/frontend/src/components/templates/CenteredTemplate.tsx
+++ b/frontend/src/components/templates/CenteredTemplate.tsx
@@ -1,8 +1,25 @@
 import React from "react";
+import NavBar from "@/components/molecules/NavBar";
 
 /** A CenteredTemplate page */
-const CenteredTemplate = () => {
-  return <>Hello there</>;
+type CenteredProps = {
+  Form: JSX.Element;
+} 
+
+
+const CenteredTemplate = ( { Form }: CenteredProps) => {
+  return (
+    <div className="flex flex-col h-screen">
+      <div>
+        <NavBar />
+      </div>
+        <div className="flex items-center justify-center bg-white">
+          <div className="w-full sm:px-32 sm:py-10 px-16 py-10">
+            {Form}
+          </div>
+        </div>
+      </div>
+  );
 };
 
 export default CenteredTemplate;

--- a/frontend/src/components/templates/CenteredTemplate.tsx
+++ b/frontend/src/components/templates/CenteredTemplate.tsx
@@ -2,23 +2,18 @@ import React from "react";
 import NavBar from "@/components/molecules/NavBar";
 
 /** A CenteredTemplate page */
-type CenteredProps = {
-  Form: JSX.Element;
-} 
+type CenteredTemplateProps = {
+  body: React.ReactElement;
+};
 
-
-const CenteredTemplate = ( { Form }: CenteredProps) => {
+const CenteredTemplate = ({ body }: CenteredTemplateProps) => {
   return (
     <div className="flex flex-col h-screen">
-      <div>
-        <NavBar />
+      <NavBar />
+      <div className="flex items-center justify-center bg-white">
+        <div className="w-full sm:px-32 sm:py-10 px-16 py-10">{body}</div>
       </div>
-        <div className="flex items-center justify-center bg-white">
-          <div className="w-full sm:px-32 sm:py-10 px-16 py-10">
-            {Form}
-          </div>
-        </div>
-      </div>
+    </div>
   );
 };
 

--- a/frontend/src/pages/events/[eventid]/edit.tsx
+++ b/frontend/src/pages/events/[eventid]/edit.tsx
@@ -7,11 +7,7 @@ import CenteredTemplate from "@/components/templates/CenteredTemplate";
 const EditEvent = () => {
   const router = useRouter();
   const { eventid } = router.query;
- return( <div>
-    <CenteredTemplate Form={<EventForm eventType="edit"/> }/>
-    <p>{eventid}</p>
-  </div>
-  );
+  return <CenteredTemplate body={<EventForm eventType="edit" />} />;
 };
 
 export default EditEvent;

--- a/frontend/src/pages/events/[eventid]/edit.tsx
+++ b/frontend/src/pages/events/[eventid]/edit.tsx
@@ -1,12 +1,17 @@
 import React from "react";
-// import { useRouter } from "next/router";
+import { useRouter } from "next/router";
 import EventForm from "@/components/molecules/EventForm";
+import CenteredTemplate from "@/components/templates/CenteredTemplate";
 
 /** An EditEvent page */
 const EditEvent = () => {
-  //const router = useRouter();
-  //const { eventid } = router.query;
-  return <EventForm eventType="edit" />;
+  const router = useRouter();
+  const { eventid } = router.query;
+ return( <div>
+    <CenteredTemplate Form={<EventForm eventType="edit"/> }/>
+    <p>{eventid}</p>
+  </div>
+  );
 };
 
 export default EditEvent;

--- a/frontend/src/pages/events/create.tsx
+++ b/frontend/src/pages/events/create.tsx
@@ -4,11 +4,7 @@ import CenteredTemplate from "@/components/templates/CenteredTemplate";
 
 /** A CreateEvent page */
 const CreateEvent = () => {
-  return (
-    <div>
-      <CenteredTemplate Form={<EventForm eventType="create"/> }/>
-    </div>
-  );
+  return <CenteredTemplate body={<EventForm eventType="create" />} />;
 };
 
 export default CreateEvent;

--- a/frontend/src/pages/events/create.tsx
+++ b/frontend/src/pages/events/create.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 import EventForm from "@/components/molecules/EventForm";
+import CenteredTemplate from "@/components/templates/CenteredTemplate";
 
 /** A CreateEvent page */
 const CreateEvent = () => {
   return (
     <div>
-      <EventForm eventType="create" />
+      <CenteredTemplate Form={<EventForm eventType="create"/> }/>
     </div>
   );
 };


### PR DESCRIPTION
## Summary

Created CenteredTemplate and implemented create event and edit event. Closes #56.

## Testing

run `yarn run dev` when in the frontend folder and navigate to:
http://localhost:3000/events/create to see create event page
http://localhost:3000/events/eventid/edit to see edit event page

## Notes

**Padding:** It took a very large amount of padding (px-96) to make the page have a similar amount of padding as that in the Figma page (right now the template has implemented px-16).

**Copy Link Button:** The copy link button was for some reason not wrapping with the form as nicely as expected (it seems to be somehow detached from the entire form itself), so, it sits on the page as though there is no padding.

Create Event Page in Desktop View:
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/81458184/235391408-638b7518-6ec9-4ccc-a1bd-b474347202d8.png">
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/81458184/235392338-2122929d-c3b1-4af5-a354-b77f7d2e8b9b.png">

Create Event Page in Mobile View:
<img width="355" alt="image" src="https://user-images.githubusercontent.com/81458184/235391371-86b1f12e-d750-4185-818f-9a33654138b3.png">
<img width="348" alt="image" src="https://user-images.githubusercontent.com/81458184/235392162-0f60ba32-92f7-471c-b6b7-6f781f365c31.png">

Edit Event Page in Desktop View:
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/81458184/235391468-672949c0-66e5-405a-bf2d-96403a7c532d.png">
<img width="1512" alt="image" src="https://user-images.githubusercontent.com/81458184/235392200-4df3f691-fb47-4a15-ba78-4a996bb898af.png">

Edit Event Page in Mobile View:
<img width="355" alt="image" src="https://user-images.githubusercontent.com/81458184/235391506-e37b1e61-ebf1-4d18-af71-938fefb64938.png">
<img width="360" alt="image" src="https://user-images.githubusercontent.com/81458184/235392282-ee6b51cd-bbbf-4a68-85ad-942d6b842c98.png">

