### PR TITLE
Events users backend

### DIFF
--- a/backend/api-spec.json
+++ b/backend/api-spec.json
@@ -83,7 +83,58 @@
           "Users"
         ],
         "description": "",
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "eventid",
+            "in": "query",
+            "type": "string"
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "type": "string"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "type": "string"
+          },
+          {
+            "name": "email",
+            "in": "query",
+            "type": "string"
+          },
+          {
+            "name": "role",
+            "in": "query",
+            "type": "string"
+          },
+          {
+            "name": "hours",
+            "in": "query",
+            "type": "string"
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "type": "string"
+          },
+          {
+            "name": "firstName",
+            "in": "query",
+            "type": "string"
+          },
+          {
+            "name": "lastName",
+            "in": "query",
+            "type": "string"
+          },
+          {
+            "name": "nickname",
+            "in": "query",
+            "type": "string"
+          }
+        ],
         "responses": {}
       }
     },
@@ -410,7 +461,38 @@
           "Events"
         ],
         "description": "",
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "upcoming",
+            "in": "query",
+            "type": "string"
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "type": "string"
+          },
+          {
+            "name": "ownerid",
+            "in": "query",
+            "type": "string"
+          },
+          {
+            "name": "userid",
+            "in": "query",
+            "type": "string"
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "type": "string"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "type": "string"
+          }
+        ],
         "responses": {}
       }
     },

--- a/backend/api-spec.json
+++ b/backend/api-spec.json
@@ -85,17 +85,17 @@
         "description": "",
         "parameters": [
           {
-            "name": "eventid",
+            "name": "firstName",
             "in": "query",
             "type": "string"
           },
           {
-            "name": "after",
+            "name": "lastName",
             "in": "query",
             "type": "string"
           },
           {
-            "name": "limit",
+            "name": "nickname",
             "in": "query",
             "type": "string"
           },
@@ -120,17 +120,22 @@
             "type": "string"
           },
           {
-            "name": "firstName",
+            "name": "eventId",
             "in": "query",
             "type": "string"
           },
           {
-            "name": "lastName",
+            "name": "sort",
             "in": "query",
             "type": "string"
           },
           {
-            "name": "nickname",
+            "name": "after",
+            "in": "query",
+            "type": "string"
+          },
+          {
+            "name": "limit",
             "in": "query",
             "type": "string"
           }
@@ -468,17 +473,17 @@
             "type": "string"
           },
           {
-            "name": "sort",
-            "in": "query",
-            "type": "string"
-          },
-          {
             "name": "ownerid",
             "in": "query",
             "type": "string"
           },
           {
             "name": "userid",
+            "in": "query",
+            "type": "string"
+          },
+          {
+            "name": "sort",
             "in": "query",
             "type": "string"
           },

--- a/backend/src/events/controllers.ts
+++ b/backend/src/events/controllers.ts
@@ -46,13 +46,10 @@ const deleteEvent = async (eventID: string) => {
 
 /**
  * Search, sort and pagination for events
- * [option] corresponds to the columns in the Event table.
- * Search supports multiple queries
- * The following options are supported:
  * @param filter are the filter params passed in
  * @param sort are sort params passed in
  * @param pagination are the pagination params passed in
- * @returns promise with list of all events where [option] is [value]
+ * @returns promise with list of events
  */
 const getEvents = async (
   filter: {

--- a/backend/src/events/controllers.ts
+++ b/backend/src/events/controllers.ts
@@ -62,7 +62,7 @@ const getEvents = async (req: Request) => {
       };
     }
   }
-  const sortQuery = req.query.sort as string;
+  const sortQuery = query.sort as string;
   const querySplit = sortQuery ? sortQuery.split(":") : ["default", "asc"];
   const key: string = querySplit[0];
   const order = querySplit[1] as Prisma.SortOrder;
@@ -71,6 +71,13 @@ const getEvents = async (req: Request) => {
     name: [{ name: order }],
     location: [{ location: order }],
   };
+
+  const ownerId = query.ownerid;
+  if (ownerId) {
+    whereDict["ownerId"] = ownerId;
+  }
+
+  console.log("whereDict", whereDict)
 
   return prisma.event.findMany({
     where: whereDict,
@@ -81,7 +88,6 @@ const getEvents = async (req: Request) => {
     // },
   });
 };
-
 /**
  * Updates an event
  * @param event (Event) event body

--- a/backend/src/events/controllers.ts
+++ b/backend/src/events/controllers.ts
@@ -105,7 +105,7 @@ const getEvents = async (req: Request) => {
 
   if (query.limit) {
     take = parseInt(query.limit as string);
-  }else{
+  } else {
     // default take is 10
     take = 10;
   }

--- a/backend/src/events/controllers.ts
+++ b/backend/src/events/controllers.ts
@@ -42,8 +42,22 @@ const deleteEvent = async (eventID: string) => {
  * Get all events in DB
  * @returns promise with all events or error
  */
-const getEvents = async () => {
-  return prisma.event.findMany({});
+const getEvents = async (
+  req?: Request,
+  upcoming?: boolean
+  // sort?:
+) => {
+  //TODO
+  let whereDict: { [key: string]: any } = {};
+  if (upcoming) {
+    const dateTime = new Date();
+    whereDict["startDate"] = {
+      gt: dateTime,
+    };
+  }
+  return prisma.event.findMany({
+    where: whereDict,
+  });
 };
 
 /**

--- a/backend/src/events/controllers.ts
+++ b/backend/src/events/controllers.ts
@@ -100,7 +100,7 @@ const getEvents = async (
   let whereDict: { [key: string]: any } = {};
   let includeDict: { [key: string]: any } = {};
 
-  // GET /events?upcoming=true
+  // Handles GET /events?upcoming=true
   if (filter.upcoming === "true") {
     const dateTime = new Date();
     whereDict["startDate"] = {

--- a/backend/src/events/controllers.ts
+++ b/backend/src/events/controllers.ts
@@ -71,13 +71,14 @@ const getEvents = async (req: Request) => {
     }
   }
   const sortQuery = query.sort as string;
+  const defaultCursor = { id: "asc" };
   const querySplit = sortQuery ? sortQuery.split(":") : ["default", "asc"];
   const key: string = querySplit[0];
   const order = querySplit[1] as Prisma.SortOrder;
   const sortDict: { [key: string]: any } = {
     default: { id: order },
-    name: [{ name: order }],
-    location: [{ location: order }],
+    name: [{ name: order }, defaultCursor],
+    location: [{ location: order }, defaultCursor],
   };
 
   const ownerId = query.ownerid;
@@ -94,7 +95,6 @@ const getEvents = async (req: Request) => {
     includeDict["attendees"] = true;
   }
 
-
   return prisma.event.findMany({
     where: {
       AND: [whereDict],
@@ -102,9 +102,9 @@ const getEvents = async (req: Request) => {
     include: includeDict,
     orderBy: sortDict[key],
     take: query.limit ? parseInt(query.limit as string) : 10,
-    // cursor: {
-    //   id: query.after ? (query.after as string) : undefined,
-    // },
+    cursor: {
+      id: query.after ? (query.after as string) : "",
+    },
   });
 };
 /**

--- a/backend/src/events/controllers.ts
+++ b/backend/src/events/controllers.ts
@@ -105,6 +105,9 @@ const getEvents = async (req: Request) => {
 
   if (query.limit) {
     take = parseInt(query.limit as string);
+  }else{
+    // default take is 10
+    take = 10;
   }
 
   const queryResult = await prisma.event.findMany({

--- a/backend/src/events/controllers.ts
+++ b/backend/src/events/controllers.ts
@@ -92,7 +92,6 @@ const getEvents = async (req: Request) => {
         userId: userId,
       },
     };
-    includeDict["attendees"] = true;
   }
   let cursor = undefined;
   let skip = undefined;

--- a/backend/src/events/views.ts
+++ b/backend/src/events/views.ts
@@ -4,7 +4,7 @@ import { auth } from "../middleware/auth";
 import { attempt } from "../utils/helpers";
 
 import { errorJson, successJson } from "../utils/jsonResponses";
-import { EventMode, EventStatus } from "@prisma/client";
+import { EventMode, EventStatus, Prisma } from "@prisma/client";
 
 const eventRouter = Router();
 
@@ -49,7 +49,27 @@ eventRouter.delete("/:eventid", async (req: Request, res: Response) => {
 
 eventRouter.get("/", async (req: Request, res: Response) => {
   // #swagger.tags = ['Events']
-  attempt(res, 200, () => eventController.getEvents(req));
+  const filter = {
+    upcoming: req.query.upcoming as string,
+    ownerId: req.query.ownerid as string,
+    userId: req.query.userid as string,
+  };
+
+  const sortQuery = req.query.sort as string;
+  const querySplit = sortQuery ? sortQuery.split(":") : ["default", "asc"];
+  const key = querySplit[0];
+  const order = querySplit[1] as Prisma.SortOrder;
+  const sort = {
+    key: key,
+    order: order,
+  };
+
+  const pagination = {
+    after: req.query.after as string,
+    limit: req.query.limit as string,
+  };
+
+  attempt(res, 200, () => eventController.getEvents(filter, sort, pagination));
 });
 
 eventRouter.get("/upcoming", async (req: Request, res: Response) => {

--- a/backend/src/events/views.ts
+++ b/backend/src/events/views.ts
@@ -49,7 +49,8 @@ eventRouter.delete("/:eventid", async (req: Request, res: Response) => {
 
 eventRouter.get("/", async (req: Request, res: Response) => {
   // #swagger.tags = ['Events']
-  attempt(res, 200, eventController.getEvents);
+  const { upcoming } = req.body;
+  attempt(res, 200, () => eventController.getEvents(req, upcoming));
 });
 
 eventRouter.get("/upcoming", async (req: Request, res: Response) => {
@@ -60,11 +61,6 @@ eventRouter.get("/upcoming", async (req: Request, res: Response) => {
 eventRouter.get("/current", async (req: Request, res: Response) => {
   // #swagger.tags = ['Events']
   attempt(res, 200, eventController.getCurrentEvents);
-});
-
-eventRouter.get("/events", async (req: Request, res: Response) => {
-  // #swagger.tags = ['Events']
-  // TODO
 });
 
 eventRouter.get("/past", async (req: Request, res: Response) => {

--- a/backend/src/events/views.ts
+++ b/backend/src/events/views.ts
@@ -49,8 +49,7 @@ eventRouter.delete("/:eventid", async (req: Request, res: Response) => {
 
 eventRouter.get("/", async (req: Request, res: Response) => {
   // #swagger.tags = ['Events']
-  const { upcoming } = req.body;
-  attempt(res, 200, () => eventController.getEvents(req, upcoming));
+  attempt(res, 200, () => eventController.getEvents(req));
 });
 
 eventRouter.get("/upcoming", async (req: Request, res: Response) => {

--- a/backend/src/events/views.ts
+++ b/backend/src/events/views.ts
@@ -62,6 +62,11 @@ eventRouter.get("/current", async (req: Request, res: Response) => {
   attempt(res, 200, eventController.getCurrentEvents);
 });
 
+eventRouter.get("/events", async (req: Request, res: Response) => {
+  // #swagger.tags = ['Events']
+  // TODO
+});
+
 eventRouter.get("/past", async (req: Request, res: Response) => {
   // #swagger.tags = ['Events']
   attempt(res, 200, eventController.getPastEvents);

--- a/backend/src/users/controllers.ts
+++ b/backend/src/users/controllers.ts
@@ -68,7 +68,7 @@ const updateUser = async (userID: string, user: User) => {
  */
 const getUsers = async (req: Request) => {
   const query = req.query;
-
+  
   const sortQuery = req.query.sort as string;
   const querySplit = sortQuery ? sortQuery.split(":") : ["default", "asc"];
   const key: string = querySplit[0];

--- a/backend/src/users/controllers.ts
+++ b/backend/src/users/controllers.ts
@@ -66,7 +66,7 @@ const updateUser = async (userID: string, user: User) => {
  * @param filter are the filter params passed in
  * @param sort are sort params passed in
  * @param pagination are the pagination params passed in
- * @returns promise with list of all users where [option] is [value]
+ * @returns promise with list of users
  */
 const getUsers = async (
   filter: {
@@ -147,34 +147,34 @@ const getUsers = async (
   }
 
   // Handles all other filtering
+  let whereDict = {
+    events: events,
+    email: Array.isArray(filter.email) ? { in: filter.email } : filter.email,
+    role: {
+      equals: filter.role,
+    },
+    hours: filter.hours,
+    status: {
+      equals: filter.status,
+    },
+    profile: {
+      firstName: Array.isArray(filter.firstName)
+        ? { in: filter.firstName }
+        : filter.firstName,
+      lastName: Array.isArray(filter.lastName)
+        ? { in: filter.lastName }
+        : filter.lastName,
+      nickname: Array.isArray(filter.nickname)
+        ? { in: filter.nickname }
+        : filter.nickname,
+    },
+  };
+
+  /* RESULT */
+
   const queryResult = await prisma.user.findMany({
     where: {
-      AND: [
-        {
-          events: events,
-          email: Array.isArray(filter.email)
-            ? { in: filter.email }
-            : filter.email,
-          role: {
-            equals: filter.role,
-          },
-          hours: filter.hours,
-          status: {
-            equals: filter.status,
-          },
-          profile: {
-            firstName: Array.isArray(filter.firstName)
-              ? { in: filter.firstName }
-              : filter.firstName,
-            lastName: Array.isArray(filter.lastName)
-              ? { in: filter.lastName }
-              : filter.lastName,
-            nickname: Array.isArray(filter.nickname)
-              ? { in: filter.nickname }
-              : filter.nickname,
-          },
-        },
-      ],
+      AND: [whereDict],
     },
     include: {
       profile: true,
@@ -185,9 +185,6 @@ const getUsers = async (
     skip: skip,
     cursor: cursor,
   });
-
-  /* RESULT */
-
   const lastPostInResults = take
     ? queryResult[take - 1]
     : queryResult[queryResult.length - 1];

--- a/backend/src/users/controllers.ts
+++ b/backend/src/users/controllers.ts
@@ -116,6 +116,9 @@ const getUsers = async (req: Request) => {
 
   if (query.limit) {
     take = parseInt(query.limit as string);
+  }else{
+    // default limit
+    take = 10;
   }
 
   const queryResult = await prisma.user.findMany({

--- a/backend/src/users/controllers.ts
+++ b/backend/src/users/controllers.ts
@@ -116,7 +116,7 @@ const getUsers = async (req: Request) => {
 
   if (query.limit) {
     take = parseInt(query.limit as string);
-  }else{
+  } else {
     // default limit
     take = 10;
   }
@@ -153,11 +153,10 @@ const getUsers = async (req: Request) => {
       events: eventId ? true : false,
     },
     orderBy: sortDict[key],
-    
+
     take: take,
     skip: skip,
     cursor: cursor,
-    
   });
   const lastPostInResults = take
     ? queryResult[take - 1]

--- a/backend/src/users/controllers.ts
+++ b/backend/src/users/controllers.ts
@@ -68,7 +68,7 @@ const updateUser = async (userID: string, user: User) => {
  */
 const getUsers = async (req: Request) => {
   const query = req.query;
-  
+
   const sortQuery = req.query.sort as string;
   const querySplit = sortQuery ? sortQuery.split(":") : ["default", "asc"];
   const key: string = querySplit[0];
@@ -88,10 +88,22 @@ const getUsers = async (req: Request) => {
       },
     },
   };
+
+  const eventId = query.eventid;
+  let events: { [key: string]: any } = {};
+  if (eventId) {
+    events = {
+      some: {
+        eventId: eventId,
+      },
+    };
+  }
+
   return prisma.user.findMany({
     where: {
       AND: [
         {
+          events: events,
           email: Array.isArray(query.email) ? { in: query.email } : query.email,
           role: {
             equals: query.role as userRole,
@@ -116,6 +128,7 @@ const getUsers = async (req: Request) => {
     },
     include: {
       profile: true,
+      events: eventId ? true : false,
     },
     orderBy: sortDict[key],
     take: query.limit ? parseInt(query.limit as string) : 10,

--- a/backend/src/users/controllers.ts
+++ b/backend/src/users/controllers.ts
@@ -70,23 +70,30 @@ const getUsers = async (req: Request) => {
   const query = req.query;
 
   const sortQuery = req.query.sort as string;
+  const defaultCursor = { id: "asc" };
   const querySplit = sortQuery ? sortQuery.split(":") : ["default", "asc"];
   const key: string = querySplit[0];
   const order = querySplit[1] as Prisma.SortOrder;
   const sortDict: { [key: string]: any } = {
     default: { id: order },
-    email: [{ email: order }],
-    hours: [{ hours: order }],
-    firstName: {
-      profile: {
-        firstName: order,
+    email: [{ email: order }, defaultCursor],
+    hours: [{ hours: order }, defaultCursor],
+    firstName: [
+      {
+        profile: {
+          firstName: order,
+        },
       },
-    },
-    lastName: {
-      profile: {
-        lastName: order,
+      defaultCursor,
+    ],
+    lastName: [
+      {
+        profile: {
+          lastName: order,
+        },
       },
-    },
+      defaultCursor,
+    ],
   };
 
   const eventId = query.eventid;
@@ -132,9 +139,9 @@ const getUsers = async (req: Request) => {
     },
     orderBy: sortDict[key],
     take: query.limit ? parseInt(query.limit as string) : 10,
-    // cursor: {
-    //   id: query.after ? (query.after as string) : undefined,
-    // },
+    cursor: {
+      id: query.after ? (query.after as string) : "",
+    },
   });
 };
 

--- a/backend/src/users/controllers.ts
+++ b/backend/src/users/controllers.ts
@@ -66,26 +66,15 @@ const updateUser = async (userID: string, user: User) => {
  * Gets all Users in database and all data associated with each user
  * @returns promise with all users or error
  */
-const getUsers = async (
-  req: Request,
-  email?: string | string[],
-  role?: userRole,
-  firstName?: string,
-  lastName?: string,
-  nickname?: string,
-  hours?: number,
-  status?: UserStatus,
-  sort?: string,
-  limit?: number,
-  after?: string
-) => {
+const getUsers = async (req: Request) => {
   const query = req.query;
 
   const sortQuery = req.query.sort as string;
-  const querySplit = sortQuery.split(":");
+  const querySplit = sortQuery ? sortQuery.split(":") : ["default", "asc"];
   const key: string = querySplit[0];
   const order = querySplit[1] as Prisma.SortOrder;
   const sortDict: { [key: string]: any } = {
+    default: { id: order },
     email: [{ email: order }],
     hours: [{ hours: order }],
     firstName: {
@@ -130,9 +119,9 @@ const getUsers = async (
     },
     orderBy: sortDict[key],
     take: query.limit ? parseInt(query.limit as string) : 10,
-    cursor: {
-      id: query.after ? (query.after as string) : undefined,
-    },
+    // cursor: {
+    //   id: query.after ? (query.after as string) : undefined,
+    // },
   });
 };
 

--- a/backend/src/users/controllers.ts
+++ b/backend/src/users/controllers.ts
@@ -5,7 +5,6 @@ import admin from "firebase-admin";
 // We are using one connection to prisma client to prevent multiple connections
 import prisma from "../../client";
 import { setVolunteerCustomClaims } from "../middleware/auth";
-import { SortOrder } from "mongoose";
 
 /**
  * Creates a new user

--- a/backend/src/users/views.ts
+++ b/backend/src/users/views.ts
@@ -73,17 +73,40 @@ userRouter.put("/:userid", useAuth, async (req: Request, res: Response) => {
 
 userRouter.get("/", useAuth, async (req: Request, res: Response) => {
   // #swagger.tags = ['Users']
-  attempt(res, 200, userController.getAllUsers);
+
+  const {
+    email,
+    firstName,
+    lastName,
+    role,
+    status,
+    hours,
+    nickname,
+    sort,
+    limit,
+    after,
+  } = req.body;
+  attempt(res, 200, () =>
+    userController.getUsers(
+      req,
+      email,
+      firstName,
+      lastName,
+      role,
+      status,
+      hours,
+      nickname,
+      sort,
+      limit,
+      after
+    )
+  );
+  attempt(res, 200, () => userController.getUsers(req));
 });
 
 userRouter.get("/pagination", useAuth, async (req: Request, res: Response) => {
   // #swagger.tags = ['Users']
   attempt(res, 200, () => userController.getUsersPaginated(req));
-});
-
-userRouter.get("/users", useAuth, async (req: Request, res: Response) => {
-  // #swagger.tags = ['Users']
-  // TODO
 });
 
 userRouter.get("/search", useAuth, async (req: Request, res: Response) => {

--- a/backend/src/users/views.ts
+++ b/backend/src/users/views.ts
@@ -73,34 +73,6 @@ userRouter.put("/:userid", useAuth, async (req: Request, res: Response) => {
 
 userRouter.get("/", useAuth, async (req: Request, res: Response) => {
   // #swagger.tags = ['Users']
-
-  const {
-    email,
-    firstName,
-    lastName,
-    role,
-    status,
-    hours,
-    nickname,
-    sort,
-    limit,
-    after,
-  } = req.body;
-  attempt(res, 200, () =>
-    userController.getUsers(
-      req,
-      email,
-      firstName,
-      lastName,
-      role,
-      status,
-      hours,
-      nickname,
-      sort,
-      limit,
-      after
-    )
-  );
   attempt(res, 200, () => userController.getUsers(req));
 });
 

--- a/backend/src/users/views.ts
+++ b/backend/src/users/views.ts
@@ -1,4 +1,5 @@
 import { Router, RequestHandler, Request, Response } from "express";
+import { Prisma, userRole, UserStatus } from "@prisma/client";
 import userController from "./controllers";
 import { auth, setVolunteerCustomClaims, NoAuth } from "../middleware/auth";
 const userRouter = Router();
@@ -73,7 +74,32 @@ userRouter.put("/:userid", useAuth, async (req: Request, res: Response) => {
 
 userRouter.get("/", useAuth, async (req: Request, res: Response) => {
   // #swagger.tags = ['Users']
-  attempt(res, 200, () => userController.getUsers(req));
+  const filter = {
+    firstName: req.query.firstName as string,
+    lastName: req.query.lastName as string,
+    nickname: req.query.nickname as string,
+    email: req.query.email as string,
+    role: req.query.role as userRole,
+    hours: req.query.hours ? parseInt(req.query.hours as string) : undefined,
+    status: req.query.status as UserStatus,
+    eventId: req.query.eventId as string,
+  };
+
+  const sortQuery = req.query.sort as string;
+  const querySplit = sortQuery ? sortQuery.split(":") : ["default", "asc"];
+  const key = querySplit[0];
+  const order = querySplit[1] as Prisma.SortOrder;
+  const sort = {
+    key: key,
+    order: order,
+  };
+
+  const pagination = {
+    after: req.query.after as string,
+    limit: req.query.limit as string,
+  };
+
+  attempt(res, 200, () => userController.getUsers(filter, sort, pagination));
 });
 
 userRouter.get("/pagination", useAuth, async (req: Request, res: Response) => {

--- a/backend/src/users/views.ts
+++ b/backend/src/users/views.ts
@@ -81,6 +81,11 @@ userRouter.get("/pagination", useAuth, async (req: Request, res: Response) => {
   attempt(res, 200, () => userController.getUsersPaginated(req));
 });
 
+userRouter.get("/users", useAuth, async (req: Request, res: Response) => {
+  // #swagger.tags = ['Users']
+  // TODO
+});
+
 userRouter.get("/search", useAuth, async (req: Request, res: Response) => {
   // #swagger.tags = ['Users']
   const { email, firstName, lastName, role, status, hours, nickname } =

--- a/backend/tests/events.test.ts
+++ b/backend/tests/events.test.ts
@@ -34,7 +34,7 @@ describe("Testing POST /events/:userid", () => {
   test("POST Create a new event", async () => {
     const users = await request(app).get("/users");
     const eventDTO = {
-      userID: `${users.body.data[1].id}`,
+      userID: `${users.body.data.result[1].id}`,
       event: {
         name: "Cool Event",
         location: "Hack Hall",
@@ -55,7 +55,7 @@ describe("Testing POST /events/:userid", () => {
   test("POST Create a new event with an empty name", async () => {
     const users = await request(app).get("/users");
     const eventDTO = {
-      userID: `${users.body.data[0].id}`,
+      userID: `${users.body.data.result[0].id}`,
       event: {},
     };
     const response = await request(app).post("/events").send(eventDTO);
@@ -69,7 +69,7 @@ describe("Testing PUT /events/:eventid", () => {
       name: "New Event",
     };
     const events = await request(app).get("/events");
-    const eventid = events.body.data[1].id;
+    const eventid = events.body.data.result[1].id;
     const response = await request(app)
       .put("/events/" + eventid)
       .send(event);
@@ -82,7 +82,7 @@ describe("Testing PUT /events/:eventid", () => {
 describe("Testing GET /events/:eventid", () => {
   test("Get existing event", async () => {
     const events = await request(app).get("/events");
-    const eventid = events.body.data[1].id;
+    const eventid = events.body.data.result[1].id;
     const response = await request(app).get("/events/" + eventid);
     expect(response.status).toBe(200);
   });
@@ -97,7 +97,7 @@ describe("Testing GET /events/:eventid", () => {
 describe("Testing GET /events/:eventid/attendees", () => {
   test("Get attendees for existing event", async () => {
     const events = await request(app).get("/events");
-    const eventid = events.body.data[0].id;
+    const eventid = events.body.data.result[0].id;
     const response = await request(app).get(
       "/events/" + eventid + "/attendees"
     );
@@ -116,7 +116,7 @@ describe("Testing GET /events/:eventid/attendees", () => {
 describe("Testing PATCH /events/:eventid/status", () => {
   test("Update event status to active", async () => {
     const events = await request(app).get("/events");
-    const eventid = events.body.data[0].id;
+    const eventid = events.body.data.result[0].id;
     const status = "ACTIVE";
     const response = await request(app)
       .patch(`/events/${eventid}/status`)
@@ -128,7 +128,7 @@ describe("Testing PATCH /events/:eventid/status", () => {
 
   test("Event status invalid", async () => {
     const events = await request(app).get("/events");
-    const eventid = events.body.data[0].id;
+    const eventid = events.body.data.result[0].id;
     const status = "COMPLETE";
     const response = await request(app)
       .patch("/events/" + eventid + "/status")
@@ -140,21 +140,20 @@ describe("Testing PATCH /events/:eventid/status", () => {
 describe("Testing PATCH /events/:eventid/owner", () => {
   test("Change current owner", async () => {
     const events = await request(app).get("/events");
-    const eventid = events.body.data[1].id;
-    const event = events.body.data[1];
+    const eventid = events.body.data.result[1].id;
     const users = await request(app).get("/users");
-    const ownerid = users.body.data[1].id;
+    const ownerid = users.body.data.result[1].id;
     const response = await request(app)
       .patch("/events/" + eventid + "/owner")
       .send({ ownerid: `${ownerid}` });
     const data = response.body.data;
     expect(response.status).toBe(200);
-    expect(data.ownerId).toBe(users.body.data[1].id);
+    expect(data.ownerId).toBe(users.body.data.result[1].id);
   });
 
   test("Change current owner to invalid", async () => {
     const events = await request(app).get("/events");
-    const eventid = events.body.data[1].id;
+    const eventid = events.body.data.result[1].id;
     const users = await request(app).get("/users");
     const ownerid = users.body.data[-1];
     const response = await request(app)
@@ -168,9 +167,9 @@ describe("Testing POST /events/:eventid/attendees", () => {
   test("Add attendee for existing event", async () => {
     const events = await request(app).get("/events");
     const users = await request(app).get("/users");
-    const eventid = events.body.data[1].id;
-    const attendeeid_1 = users.body.data[1].id;
-    const attendeeid_2 = users.body.data[2].id;
+    const eventid = events.body.data.result[1].id;
+    const attendeeid_1 = users.body.data.result[1].id;
+    const attendeeid_2 = users.body.data.result[2].id;
     const attendee1 = {
       attendeeid: `${attendeeid_1}`,
     };
@@ -185,6 +184,7 @@ describe("Testing POST /events/:eventid/attendees", () => {
       .send(attendee2);
     expect(response.status).toBe(200);
     expect(response_too.status).toBe(200);
+    
   });
 });
 
@@ -192,8 +192,8 @@ describe("Testing PATCH /events/:eventid/attendees/:attendeeid/confirm", () => {
   test("Update attendee as showed up", async () => {
     const events = await request(app).get("/events");
     const attendees = await request(app).get("/users");
-    const eventid = events.body.data[1].id;
-    const attendeeid = attendees.body.data[1].id;
+    const eventid = events.body.data.result[1].id;
+    const attendeeid = attendees.body.data.result[1].id;
     const response = await request(app).patch(
       "/events/" + eventid + "/attendees/" + attendeeid + "/confirm"
     );
@@ -204,7 +204,7 @@ describe("Testing PATCH /events/:eventid/attendees/:attendeeid/confirm", () => {
 
   test("Invalid update attendee as showed up", async () => {
     const attendees = await request(app).get("/users");
-    const attendeeid = attendees.body.data[0].id;
+    const attendeeid = attendees.body.data.result[0].id;
     const response = await request(app).patch(
       "/events/" + -1 + "/attendees/" + attendeeid + "/confirm"
     );
@@ -216,8 +216,8 @@ describe("Testing DELETE /events/:eventid/attendees/:attendeeid", () => {
   test("Delete an attendee", async () => {
     const events = await request(app).get("/events");
     const attendees = await request(app).get("/users");
-    const eventid = events.body.data[1].id;
-    const attendeeid = attendees.body.data[1].id;
+    const eventid = events.body.data.result[1].id;
+    const attendeeid = attendees.body.data.result[1].id;
     const response = await request(app).delete(
       "/events/" + eventid + "/attendees/" + attendeeid
     );
@@ -227,8 +227,8 @@ describe("Testing DELETE /events/:eventid/attendees/:attendeeid", () => {
 
   test("Delete an invalid attendee", async () => {
     const events = await request(app).get("/events");
-    const eventid = events.body.data[1].id;
-    const attendeeid = events.body.data[1].userID;
+    const eventid = events.body.data.result[1].id;
+    const attendeeid = events.body.data.result[1].userID;
     const response = await request(app).delete(
       "/events/" + eventid + "/attendees/" + attendeeid
     );
@@ -240,7 +240,7 @@ describe("Testing DELETE /events/:eventid/attendees/:attendeeid", () => {
 describe("Testing DELETE event", () => {
   test("Delete valid event", async () => {
     const events = await request(app).get("/events");
-    const eventid = events.body.data[2].id;
+    const eventid = events.body.data.result[2].id;
     const response = await request(app).delete("/events/" + eventid);
     expect(response.status).toBe(200);
     const deletedEvent = await request(app).get("/events/" + eventid);

--- a/backend/tests/events.test.ts
+++ b/backend/tests/events.test.ts
@@ -184,7 +184,6 @@ describe("Testing POST /events/:eventid/attendees", () => {
       .send(attendee2);
     expect(response.status).toBe(200);
     expect(response_too.status).toBe(200);
-    
   });
 });
 

--- a/backend/tests/users.test.ts
+++ b/backend/tests/users.test.ts
@@ -232,7 +232,6 @@ describe("Testing GET /users/:userid/profile", () => {
     expect(response.body.data.profile.firstName).toEqual(userProfile.firstName);
     expect(response.body.data.profile.lastName).toEqual(userProfile.lastName);
   });
-
 });
 
 describe("Testing GET /users/:userid/role", () => {
@@ -300,18 +299,14 @@ describe("Testing /users/:userID", () => {
 
 describe("Testing /users/sorting/", () => {
   test("GET users sorted by firstName in ascending order with null profiles", async () => {
-    const response = await request(app).get(
-      "/users/?sort=firstName:asc"
-    );
+    const response = await request(app).get("/users/?sort=firstName:asc");
     const data = response.body.data.result;
     expect(data[0].profile.firstName >= data[1].profile.firstName);
     expect(response.status).toBe(200);
   });
 
   test("GET users sorted by firstName in descending order with null profiles", async () => {
-    const response = await request(app).get(
-      "/users?sort=firstName:desc"
-    );
+    const response = await request(app).get("/users?sort=firstName:desc");
     const data = response.body.data.result;
     expect(data[0].profile == null); //any null profiles should show up first
     expect(data[0].profile.firstName <= data[1].profile.firstName);
@@ -335,9 +330,7 @@ describe("Testing /users/sorting/", () => {
 
 describe("Testing /users/:userID/created", () => {
   test("GET createdEvents of user with created events", async () => {
-    const POSTresponse = await request(app).get(
-      "/users?firstName=Prisma"
-    );
+    const POSTresponse = await request(app).get("/users?firstName=Prisma");
     const userID = POSTresponse.body.data.result[0].id;
 
     const response = await request(app).get("/users/" + userID + "/created");
@@ -353,9 +346,7 @@ describe("Testing /users/:userID/created", () => {
 
 describe("Testing /users/:userID/registered", () => {
   test("GET registeredEvents of user with registered events", async () => {
-    const POSTresponse = await request(app).get(
-      "/users?firstName=Alice"
-    );
+    const POSTresponse = await request(app).get("/users?firstName=Alice");
     const userID = POSTresponse.body.data.result[0].id;
     const GETresponse = await request(app).get("/users?userId=" + userID);
     expect(GETresponse.status).toBe(200);
@@ -370,9 +361,7 @@ describe("Testing /users/:userID/registered", () => {
 
 describe("Testing /users/:userID/hours", () => {
   test("GET hours of user", async () => {
-    const POSTresponse = await request(app).get(
-      "/users?firstName=Prisma"
-    );
+    const POSTresponse = await request(app).get("/users?firstName=Prisma");
     const userID = POSTresponse.body.data.result[0].id;
 
     const GETresponse = await request(app).get("/users/" + userID + "/hours");
@@ -392,34 +381,31 @@ describe("Testing GET /users/pagination", () => {
   test("Get 2 users after the second use", async () => {
     const users = await request(app).get("/users?limit=3");
     const cursor = users.body.data.cursor;
-    const response = await request(app).get(
-      "/users?limit=2&after=" + cursor
-    );
+    const response = await request(app).get("/users?limit=2&after=" + cursor);
     const data = response.body.data.result;
     expect(response.status).toBe(200);
     expect(data.length).toBe(2);
   });
 
-  test("Pagination without /pagination" , async () => {
+  test("Pagination without /pagination", async () => {
     const users = await request(app).get("/users?limit=3");
     const data = users.body.data;
     expect(users.status).toBe(200);
     expect(data.result.length).toBe(3);
-  }
-  );
+  });
 
   test("Get 10 users after the second use", async () => {
     // limit should be defaulted to 10
     const users = await request(app).get("/users");
     const cursor = users.body.data.cursor;
-    const response = await request(app).get(
-      "/users?after=" + cursor
-    );
+    const response = await request(app).get("/users?after=" + cursor);
     expect(response.status).toBe(200);
     expect(users.body.data.result.length).toBe(10);
     expect(response.body.data.result.length).toBe(10);
     // check that next fecth with cursor is different from prev
-    expect(users.body.data.result[0].id).not.toBe(response.body.data.result[0].id);
+    expect(users.body.data.result[0].id).not.toBe(
+      response.body.data.result[0].id
+    );
   });
 });
 

--- a/backend/tests/users.test.ts
+++ b/backend/tests/users.test.ts
@@ -38,8 +38,8 @@ describe("Testing PUT /users/:userid", () => {
     };
 
     // This is temporary till we create an endpoint to get a specific user
-    const users = await request(app).get("/users");
-    const userid = users.body.data[1].id;
+    const users = await request(app).get("/users?limit=10");
+    const userid = users.body.data.result[9].id;
 
     const response = await request(app)
       .put("/users/" + userid)
@@ -120,7 +120,7 @@ describe("Testing PATCH /users/:userid/role", () => {
   test("PATCH edit a user's role with an existing role", async () => {
     // This is temporary till we create an endpoint to get a specific user
     const users = await request(app).get("/users");
-    const userid = users.body.data[1].id;
+    const userid = users.body.data.result[9].id;
     const response = await request(app)
       .patch("/users/" + userid + "/role")
       .send({ role: "SUPERVISOR" });
@@ -133,8 +133,8 @@ describe("Testing PATCH /users/:userid/role", () => {
 describe("Testing PATCH /users/:userid/status", () => {
   test("PATCH edit a user's status with an existing status", async () => {
     // This is temporary till we create an endpoint to get a specific user
-    const users = await request(app).get("/users");
-    const userid = users.body.data[1].id;
+    const users = await request(app).get("/users?limit=10");
+    const userid = users.body.data.result[9].id;
     const response = await request(app)
       .patch("/users/" + userid + "/status")
       .send({ status: "INACTIVE" });
@@ -147,8 +147,8 @@ describe("Testing PATCH /users/:userid/status", () => {
 describe("Testing PATCH /users/:userid/hours", () => {
   test("PATCH edit a user's hours with an existing hours", async () => {
     // This is temporary till we create an endpoint to get a specific user
-    const users = await request(app).get("/users");
-    const userid = users.body.data[1].id;
+    const users = await request(app).get("/users?limit=10");
+    const userid = users.body.data.result[9].id;
     const response = await request(app)
       .patch("/users/" + userid + "/hours")
       .send({ hours: 10 });
@@ -223,38 +223,30 @@ describe("Testing /users/search", () => {
 describe("Testing GET /users/:userid/profile", () => {
   test("GET user's profile", async () => {
     // This is temporary till we create an endpoint to get a specific user
-    const users = await request(app).get("/users");
-    const userid = users.body.data[0].id;
+    const users = await request(app).get("/users?limit=10");
+    const userid = users.body.data.result[9].id;
+    const userProfile = users.body.data.result[9].profile;
 
     const response = await request(app).get("/users/" + userid + "/profile");
     expect(response.status).toBe(200);
+    expect(response.body.data.profile.firstName).toEqual(userProfile.firstName);
+    expect(response.body.data.profile.lastName).toEqual(userProfile.lastName);
   });
 
-  test("GET 2nd user's profile", async () => {
-    const user = {
-      email: "jdo583@cornell.edu",
-    };
-
-    const users = await request(app).get("/users");
-    const userid = users.body.data[1].id;
-
-    const response = await request(app).get("/users/" + userid + "/profile");
-    expect(response.status).toBe(200);
-  });
 });
 
 describe("Testing GET /users/:userid/role", () => {
   test("GET supervisor user's role", async () => {
-    const users = await request(app).get("/users");
-    const userid = users.body.data[1].id;
+    const users = await request(app).get("/users?limit=2");
+    const userid = users.body.data.result[1].id;
 
     const response = await request(app).get("/users/" + userid + "/role");
     expect(response.status).toBe(200);
   });
 
   test("GET user's default role", async () => {
-    const users = await request(app).get("/users");
-    const userid = users.body.data[0].id;
+    const users = await request(app).get("/users?limit=2");
+    const userid = users.body.data.result[0].id;
 
     const response = await request(app).get("/users/" + userid + "/role");
     expect(response.status).toBe(200);
@@ -263,8 +255,8 @@ describe("Testing GET /users/:userid/role", () => {
 
 describe("Testing GET /users/:userid/preferences", () => {
   test("GET user's default preferences", async () => {
-    const users = await request(app).get("/users");
-    const userid = users.body.data[0].id;
+    const users = await request(app).get("/users?limit=2");
+    const userid = users.body.data.result[0].id;
 
     const response = await request(app).get(
       "/users/" + userid + "/preferences"
@@ -273,72 +265,13 @@ describe("Testing GET /users/:userid/preferences", () => {
   });
 
   test("GET user's non-default preferences", async () => {
-    const users = await request(app).get("/users");
-    const userid = users.body.data[1].id;
+    const users = await request(app).get("/users?limit=2");
+    const userid = users.body.data.result[1].id;
 
     const response = await request(app).get(
       "/users/" + userid + "/preferences"
     );
     const data = response.body.data;
-    expect(response.status).toBe(200);
-  });
-});
-
-describe("Testing GET /users/:userid/profile", () => {
-  test("GET user's profile", async () => {
-    // This is temporary till we create an endpoint to get a specific user
-    const users = await request(app).get("/users");
-    const userid = users.body.data[0].id;
-
-    const response = await request(app).get("/users/" + userid + "/profile");
-    expect(response.status).toBe(200);
-  });
-
-  test("GET 2nd user's profile", async () => {
-    const users = await request(app).get("/users");
-    const userid = users.body.data[1].id;
-
-    const response = await request(app).get("/users/" + userid + "/profile");
-    expect(response.status).toBe(200);
-  });
-});
-
-describe("Testing GET /users/:userid/role", () => {
-  test("GET supervisor user's role", async () => {
-    const users = await request(app).get("/users");
-    const userid = users.body.data[1].id;
-
-    const response = await request(app).get("/users/" + userid + "/role");
-    expect(response.status).toBe(200);
-  });
-
-  test("GET user's default role", async () => {
-    const users = await request(app).get("/users");
-    const userid = users.body.data[0].id;
-
-    const response = await request(app).get("/users/" + userid + "/role");
-    expect(response.status).toBe(200);
-  });
-});
-
-describe("Testing GET /users/:userid/preferences", () => {
-  test("GET user's default preferences", async () => {
-    const users = await request(app).get("/users");
-    const userid = users.body.data[0].id;
-
-    const response = await request(app).get(
-      "/users/" + userid + "/preferences"
-    );
-    expect(response.status).toBe(200);
-  });
-
-  test("GET user's non-default preferences", async () => {
-    const users = await request(app).get("/users");
-    const userid = users.body.data[1].id;
-
-    const response = await request(app).get(
-      "/users/" + userid + "/preferences"
-    );
     expect(response.status).toBe(200);
   });
 });
@@ -368,43 +301,33 @@ describe("Testing /users/:userID", () => {
 describe("Testing /users/sorting/", () => {
   test("GET users sorted by firstName in ascending order with null profiles", async () => {
     const response = await request(app).get(
-      "/users/sorting?sort=firstName:asc"
+      "/users/?sort=firstName:asc"
     );
-    const data = response.body.data;
+    const data = response.body.data.result;
     expect(data[0].profile.firstName >= data[1].profile.firstName);
     expect(response.status).toBe(200);
   });
 
   test("GET users sorted by firstName in descending order with null profiles", async () => {
     const response = await request(app).get(
-      "/users/sorting?sort=firstName:desc"
+      "/users?sort=firstName:desc"
     );
-    const data = response.body.data;
+    const data = response.body.data.result;
     expect(data[0].profile == null); //any null profiles should show up first
     expect(data[0].profile.firstName <= data[1].profile.firstName);
     expect(response.status).toBe(200);
   });
 
-  test("GET users sorted by lastName in descending order wkith null profiles", async () => {
-    const response = await request(app).get(
-      "/users/sorting?sort=firstName:desc"
-    );
-    const data = response.body.data;
-    expect(data[0].profile == null); //any null profiles should show up first
-    expect(data[0].profile.lastName <= data[1].profile.lastName);
-    expect(response.status).toBe(200);
-  });
-
   test("GET users sorted by hours in descending order", async () => {
-    const response = await request(app).get("/users/sorting?sort=hours:desc");
-    const data = response.body.data;
+    const response = await request(app).get("/users?sort=hours:desc");
+    const data = response.body.data.result;
     expect(data[0].hours <= data[1].hours);
     expect(response.status).toBe(200);
   });
 
   test("GET users sorted by email in ascending order", async () => {
-    const response = await request(app).get("/users/sorting?sort=email:asc");
-    const data = response.body.data;
+    const response = await request(app).get("/users?sort=email:asc");
+    const data = response.body.data.result;
     expect(data[0].email <= data[1].email);
     expect(response.status).toBe(200);
   });
@@ -413,12 +336,11 @@ describe("Testing /users/sorting/", () => {
 describe("Testing /users/:userID/created", () => {
   test("GET createdEvents of user with created events", async () => {
     const POSTresponse = await request(app).get(
-      "/users/search?firstName=Prisma"
+      "/users?firstName=Prisma"
     );
-    const userID = POSTresponse.body.data[0].id;
+    const userID = POSTresponse.body.data.result[0].id;
 
     const response = await request(app).get("/users/" + userID + "/created");
-    const data = response.body.data;
     expect(response.status).toBe(200);
   });
 
@@ -432,13 +354,10 @@ describe("Testing /users/:userID/created", () => {
 describe("Testing /users/:userID/registered", () => {
   test("GET registeredEvents of user with registered events", async () => {
     const POSTresponse = await request(app).get(
-      "/users/search?firstName=Alice"
+      "/users?firstName=Alice"
     );
-    const userID = POSTresponse.body.data[0].id;
-
-    const GETresponse = await request(app).get(
-      "/users/" + userID + "/registered"
-    );
+    const userID = POSTresponse.body.data.result[0].id;
+    const GETresponse = await request(app).get("/users?userId=" + userID);
     expect(GETresponse.status).toBe(200);
   });
 
@@ -452,9 +371,9 @@ describe("Testing /users/:userID/registered", () => {
 describe("Testing /users/:userID/hours", () => {
   test("GET hours of user", async () => {
     const POSTresponse = await request(app).get(
-      "/users/search?firstName=Prisma"
+      "/users?firstName=Prisma"
     );
-    const userID = POSTresponse.body.data[0].id;
+    const userID = POSTresponse.body.data.result[0].id;
 
     const GETresponse = await request(app).get("/users/" + userID + "/hours");
     const data = GETresponse.body.data;
@@ -471,24 +390,36 @@ describe("Testing /users/:userID/hours", () => {
 
 describe("Testing GET /users/pagination", () => {
   test("Get 2 users after the second use", async () => {
-    const users = await request(app).get("/users");
-    const userid = users.body.data[2].id;
+    const users = await request(app).get("/users?limit=3");
+    const cursor = users.body.data.cursor;
     const response = await request(app).get(
-      "/users/pagination?limit=2&after=" + userid
+      "/users?limit=2&after=" + cursor
     );
-    const data = response.body.data;
+    const data = response.body.data.result;
     expect(response.status).toBe(200);
     expect(data.length).toBe(2);
   });
 
+  test("Pagination without /pagination" , async () => {
+    const users = await request(app).get("/users?limit=3");
+    const data = users.body.data;
+    expect(users.status).toBe(200);
+    expect(data.result.length).toBe(3);
+  }
+  );
+
   test("Get 10 users after the second use", async () => {
     // limit should be defaulted to 10
     const users = await request(app).get("/users");
-    const userid = users.body.data[2].id;
+    const cursor = users.body.data.cursor;
     const response = await request(app).get(
-      "/users/pagination?after=" + userid
+      "/users?after=" + cursor
     );
     expect(response.status).toBe(200);
+    expect(users.body.data.result.length).toBe(10);
+    expect(response.body.data.result.length).toBe(10);
+    // check that next fecth with cursor is different from prev
+    expect(users.body.data.result[0].id).not.toBe(response.body.data.result[0].id);
   });
 });
 
@@ -496,7 +427,7 @@ describe("Testing GET /users/pagination", () => {
 describe("Testing DELETE /users/:userid", () => {
   test("Delete valid user", async () => {
     const users = await request(app).get("/users");
-    const userid = users.body.data[0].id;
+    const userid = users.body.data.result[0].id;
     const response = await request(app).delete("/users/" + userid);
     expect(response.status).toBe(200);
 


### PR DESCRIPTION
## Summary
- Closes #114 
- Consolidates `GET /users` search, sort, and pagination functionalities. 
- Consolidates `GET /events` sort and pagination functionalities. 

`GET /users/:userid/created` -> `GET /events?ownerid=[userid]`
(note: `GET /users/:userid/created` doesn't return a list of events currently, but assumed functionality is that it should) 

`GET /users/:userid/registered` -> `GET /events?userid=[userid]`
Note how for this specific query, it includes `attendees` as part of the response 
<img width="500" alt="image" src="https://github.com/cornellh4i/lagos-volunteers/assets/44273288/152c3b26-4657-4277-89e5-d8e430e6e6e9"/>

`GET /events/:eventid/attendees `->  `GET /users?:eventid=[eventid]`
<img width="500" alt="image" src="https://github.com/cornellh4i/lagos-volunteers/assets/44273288/9e3185db-56cd-4114-8f86-73d17ceb4d03"/>

## Testing
- Checkout `events-users-backend`
- Request should be in the format of `GET /api/users?` and `GET /api/events?` 
- Sample requests: 
http://localhost:8000/events?ownerid=[ownerid]&after=[id]
http://localhost:8000/events?ownerid=[ownerid]&upcoming=true&after=[id]
http://localhost:8000/events?upcoming=true&sort=location:desc&limit=20&after=[id]
http://localhost:8000/users?firstName=Alice&sort=email:asc&limit=100&after=[id]
> Note: IDs will be different each time. We recommend testing manually alongside with Prisma Studio (for filtering, sorting, etc.)


## Testing on Pagination
Previously we were worried that Prisma cannot take a column that is not unique. Now setting the id to be a tuple `(search, id)` guarantees its uniqueness.

### User Query

Filter by volunteer, sorted according to email, take the first 10 (default) after cursor `felipa34@yahoo.com, id`.

Expectation: we expect the 10th one to be `marilou71@hotmail.com`.
<img width="500" alt="image" src="https://github.com/cornellh4i/lagos-volunteers/assets/68068854/062685b9-657d-423d-91a3-5c874fd1e04a">

Result: Indeed the last one is `marilou71@hotmail.com`. The other ones are manually checked.
<img width="700" alt="image" src="https://github.com/cornellh4i/lagos-volunteers/assets/68068854/12c4cd0c-ee3b-4ce0-89da-2ae9b383031b">

### Event Query 

Sort events in descend order, take the first 3 after cursor `soluta quos beatae, id`.

Expectation:
<img width="500" alt="image" src="https://github.com/cornellh4i/lagos-volunteers/assets/68068854/d556a362-42ec-4f4c-8fc1-4d9c0eadfdc6">

Result: 
<img width="700" alt="image" src="https://github.com/cornellh4i/lagos-volunteers/assets/68068854/10bcb650-a838-4b1d-8737-24676baf2333">

## Notes/Questions 
- We didn't remove any existing functions (search, sorting, pagination), should we? 
- Cursors must be passed in, otherwise an empty list is returned. Can we assume that cursor is always provided?

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->