### PR TITLE
Table pagination frontend 2

### DIFF
--- a/backend/src/users/controllers.ts
+++ b/backend/src/users/controllers.ts
@@ -84,6 +84,9 @@ const getUsersPaginated = async (req: Request) => {
     orderBy: {
       id: "asc",
     },
+    include: {
+      profile: true,
+    },
   });
 };
 

--- a/frontend/src/components/molecules/Table.tsx
+++ b/frontend/src/components/molecules/Table.tsx
@@ -1,72 +1,65 @@
 import React from "react";
 import Box from "@mui/material/Box";
-import {
-  DataGrid,
-  GridColDef,
-  GridColumnHeaderParams,
-  GridValueGetterParams,
-  MuiEvent,
-  gridPageCountSelector,
-  GridPagination,
-  useGridApiContext,
-  useGridSelector,
-} from "@mui/x-data-grid";
-
-import MuiPagination from "@mui/material/Pagination";
-
-interface TablePaginationProps {
-  page: number;
-  onPageChange: (event: React.MouseEvent | null, page: number) => void;
-}
-function Pagination({ page, onPageChange }: TablePaginationProps) {
-  const apiRef = useGridApiContext();
-  const pageCount = useGridSelector(apiRef, gridPageCountSelector);
-  return (
-    <MuiPagination
-      color="primary"
-      count={pageCount}
-      page={page + 1}
-      onChange={(event, newPage) => {
-        onPageChange(event as any, newPage - 1);
-      }}
-    />
-  );
-}
-
-function CustomPagination(props: any) {
-  return <GridPagination ActionsComponent={Pagination} {...props} />;
-}
+import { DataGrid, GridColDef, GridPaginationModel } from "@mui/x-data-grid";
 
 interface TableProps {
   /** The columns of the table, following the MUI Data Grid spec */
   columns: GridColDef<object>[];
   /** The table rows represented as an object array */
-  rows: Object[];
-  prevFunction: () => void;
-  nextFunction: () => void;
+  rowData: Object[];
+  /** The function called to obtain the previous elements */
+  prevFunction: () => Promise<any[]>;
+  /** The function called to obtain the next elements */
+  nextFunction: () => Promise<any[]>;
 }
 /**
  * A Table component
  */
-const Table = ({ columns, rows, prevFunction, nextFunction }: TableProps) => {
+const Table = ({
+  columns,
+  rowData,
+  prevFunction,
+  nextFunction,
+}: TableProps) => {
+  const [rows, setRows] = React.useState<any[]>(rowData);
+  // Using the cursor mdo
+  const PAGE_SIZE = 5;
+  const [paginationModel, setPaginationModel] = React.useState({
+    page: 0,
+    pageSize: PAGE_SIZE,
+  });
+
+  const handlePaginationModelChange = async (
+    newPaginationModel: GridPaginationModel
+  ) => {
+    var result = rows;
+    if (paginationModel.page < newPaginationModel.page) {
+      // means going to next
+      console.log("going forwards");
+      result = await nextFunction();
+    } else {
+      //means going to previous
+      console.log("going pervious");
+      result = await prevFunction();
+    }
+    setRows(result);
+    setPaginationModel(newPaginationModel);
+  };
+
   return (
     <DataGrid
       columns={columns}
       rows={rows}
       sx={{ border: 0 }}
       disableRowSelectionOnClick
-      pagination
-      slots={{
-        pagination: CustomPagination,
-      }}
-      {...rows}
       initialState={{
         pagination: {
           paginationModel: {
-            pageSize: 100,
+            pageSize: PAGE_SIZE,
           },
         },
       }}
+      onPaginationModelChange={handlePaginationModelChange}
       pageSizeOptions={[]}
       disableColumnMenu
 

--- a/frontend/src/components/molecules/Table.tsx
+++ b/frontend/src/components/molecules/Table.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import Box from "@mui/material/Box";
 import { DataGrid, GridColDef, GridPaginationModel } from "@mui/x-data-grid";
 
@@ -7,65 +7,103 @@ interface TableProps {
   columns: GridColDef<object>[];
   /** The table rows represented as an object array */
   rowData: Object[];
-  /** The function called to obtain the previous elements */
-  prevFunction: () => Promise<any[]>;
+  /** The length of the entire dataset if paginated */
+  dataSetLength: number;
+  /** Initial ID */
+  initialID: string;
+  /** The cursor that will progress through each page */
+  progressCursor: string;
   /** The function called to obtain the next elements */
-  nextFunction: () => Promise<any[]>;
+  nextFunction: (cursor: string) => Promise<
+    | {
+        result: any[];
+        last_user_id: string; // Adjust the type as needed
+      }
+    | undefined
+  >;
 }
 /**
  * A Table component
  */
+// initialCursor
 const Table = ({
   columns,
   rowData,
-  prevFunction,
+  dataSetLength,
+  initialID,
+  progressCursor,
   nextFunction,
 }: TableProps) => {
+  const PAGE_SIZE = 5;
   const [rows, setRows] = React.useState<any[]>(rowData);
   // Using the cursor mdo
-  const PAGE_SIZE = 5;
   const [paginationModel, setPaginationModel] = React.useState({
     page: 0,
     pageSize: PAGE_SIZE,
   });
 
+  const [cursor, setCursor] = React.useState<any[]>([initialID]);
+  const [rowCountState, setRowCountState] = React.useState(dataSetLength);
+  const [currentCursor, setCurrentCursor] =
+    React.useState<string>(progressCursor);
+
   const handlePaginationModelChange = async (
     newPaginationModel: GridPaginationModel
   ) => {
-    var result = rows;
+    // stores the result from pagination request
+    var userData = [];
+    // tracks which page we on ["","userid1","userid2"...] --> [page1,page2,page3...]
+    var cursorArray = cursor;
+    // stores which id we are using to call the pagination request.
+    var current_cursor_id: string = "";
+
     if (paginationModel.page < newPaginationModel.page) {
       // means going to next
       console.log("going forwards");
-      result = await nextFunction();
+      // get the last_user_id from rows and add to cursor list
+      const output = await nextFunction(currentCursor);
+      if (output !== undefined) {
+        cursorArray.push(currentCursor);
+        current_cursor_id = output.last_user_id;
+        userData = output.result;
+      }
     } else {
       //means going to previous
-      console.log("going pervious");
-      result = await prevFunction();
+      console.log("going previous");
+      // another pop to get the current user_id. It must be followed by a push.
+      cursorArray.pop();
+      // second pop
+      var t = cursorArray.pop();
+      cursorArray.push(t);
+      const output = await nextFunction(t);
+      if (output !== undefined) {
+        current_cursor_id = output.last_user_id;
+        userData = output.result;
+      }
     }
-    setRows(result);
+    setRows(userData);
+    setCursor(cursorArray);
+    setCurrentCursor(current_cursor_id);
     setPaginationModel(newPaginationModel);
   };
 
   return (
-    <DataGrid
-      columns={columns}
-      rows={rows}
-      sx={{ border: 0 }}
-      disableRowSelectionOnClick
-      initialState={{
-        pagination: {
-          paginationModel: {
-            pageSize: PAGE_SIZE,
-          },
-        },
-      }}
-      onPaginationModelChange={handlePaginationModelChange}
-      pageSizeOptions={[]}
-      disableColumnMenu
-
-      // getRowId={(r) => r.DT_RowId}
-      // onCellClick={{console.log(getRowId)}}
-    />
+    <div>
+      {rows.length > 0 && (
+        <DataGrid
+          columns={columns}
+          rows={rows}
+          sx={{ border: 0 }}
+          disableRowSelectionOnClick
+          rowCount={rowCountState}
+          paginationModel={paginationModel}
+          onPaginationModelChange={handlePaginationModelChange}
+          pageSizeOptions={[]}
+          paginationMode="server"
+          disableColumnMenu
+        />
+      )}
+    </div>
   );
 };
 

--- a/frontend/src/components/molecules/Table.tsx
+++ b/frontend/src/components/molecules/Table.tsx
@@ -1,29 +1,65 @@
 import React from "react";
+import Box from "@mui/material/Box";
 import {
   DataGrid,
   GridColDef,
   GridColumnHeaderParams,
   GridValueGetterParams,
   MuiEvent,
+  gridPageCountSelector,
+  GridPagination,
+  useGridApiContext,
+  useGridSelector,
 } from "@mui/x-data-grid";
+
+import MuiPagination from "@mui/material/Pagination";
+
+interface TablePaginationProps {
+  page: number;
+  onPageChange: (event: React.MouseEvent | null, page: number) => void;
+}
+function Pagination({ page, onPageChange }: TablePaginationProps) {
+  const apiRef = useGridApiContext();
+  const pageCount = useGridSelector(apiRef, gridPageCountSelector);
+  return (
+    <MuiPagination
+      color="primary"
+      count={pageCount}
+      page={page + 1}
+      onChange={(event, newPage) => {
+        onPageChange(event as any, newPage - 1);
+      }}
+    />
+  );
+}
+
+function CustomPagination(props: any) {
+  return <GridPagination ActionsComponent={Pagination} {...props} />;
+}
 
 interface TableProps {
   /** The columns of the table, following the MUI Data Grid spec */
   columns: GridColDef<object>[];
   /** The table rows represented as an object array */
   rows: Object[];
+  prevFunction: () => void;
+  nextFunction: () => void;
 }
-
 /**
  * A Table component
  */
-const Table = ({ columns, rows }: TableProps) => {
+const Table = ({ columns, rows, prevFunction, nextFunction }: TableProps) => {
   return (
     <DataGrid
       columns={columns}
       rows={rows}
       sx={{ border: 0 }}
       disableRowSelectionOnClick
+      pagination
+      slots={{
+        pagination: CustomPagination,
+      }}
+      {...rows}
       initialState={{
         pagination: {
           paginationModel: {

--- a/frontend/src/components/organisms/ManageUsers.tsx
+++ b/frontend/src/components/organisms/ManageUsers.tsx
@@ -220,7 +220,7 @@ const Active = () => {
   const fetchPrevUsers = async () => {
     try {
       const url = BASE_URL as string;
-      const fetchUrl = `${url}/users`;
+      const fetchUrl = `${url}/users/`;
       const userToken = await auth.currentUser?.getIdToken();
 
       const response = await fetch(fetchUrl, {
@@ -230,12 +230,20 @@ const Active = () => {
         },
       });
 
-      const data = await response.json();
-
       if (response.ok) {
-        // TODO: what should go here?
-        console.log("Previous users fetched");
-        return data["data"]
+        // Dummy function placed here just to make sure
+        // front end pagination works
+        const data = await response.json();
+        const clean_data = data["data"];
+        const result = clean_data.map((element: any) => ({
+          id: element["id"],
+          name: element["email"], // problem: the ${url}/users/ request does not provide name
+          email: element["email"],
+          role: element["role"],
+          date: dummyDate,
+          hours: element["hours"] + " hours",
+        }));
+        return result;
       }
     } catch (error) {
       console.log(error);
@@ -256,12 +264,20 @@ const Active = () => {
         },
       });
 
-      const data = await response.json();
-
       if (response.ok) {
-        // TODO: what should go here?
-        console.log("Next users fetched");
-        return data["data"]
+        // Dummy function placed here just to make sure
+        // front end pagination works
+        const data = await response.json();
+        const clean_data = data["data"];
+        const result = clean_data.map((element: any) => ({
+          id: element["id"],
+          name: element["name"],
+          email: element["location"],
+          role: element["status"],
+          date: dummyDate,
+          hours: 20 + " hours",
+        }));
+        return result;
       }
     } catch (error) {
       console.log(error);
@@ -272,7 +288,7 @@ const Active = () => {
     <div>
       <Table
         columns={eventColumns}
-        rows={dummyRows}
+        rowData={dummyRows}
         prevFunction={fetchPrevUsers}
         nextFunction={fetchNextUsers}
       />

--- a/frontend/src/components/organisms/ManageUsers.tsx
+++ b/frontend/src/components/organisms/ManageUsers.tsx
@@ -7,6 +7,8 @@ import AccountBoxIcon from "@mui/icons-material/AccountBox";
 import SearchBar from "@/components/atoms/SearchBar";
 import IconText from "../atoms/IconText";
 import Link from "next/link";
+import { auth } from "@/utils/firebase";
+import { BASE_URL } from "@/utils/constants";
 
 interface ManageUsersProps {}
 
@@ -214,9 +216,66 @@ const Active = () => {
     },
   ];
 
+  // Dummy FETCH function
+  const fetchPrevUsers = async () => {
+    try {
+      const url = BASE_URL as string;
+      const fetchUrl = `${url}/users`;
+      const userToken = await auth.currentUser?.getIdToken();
+
+      const response = await fetch(fetchUrl, {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${userToken}`,
+        },
+      });
+
+      const data = await response.json();
+
+      if (response.ok) {
+        // TODO: what should go here?
+        console.log("Previous users fetched");
+        return data["data"]
+      }
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  // Dummy FETCH function
+  const fetchNextUsers = async () => {
+    try {
+      const url = BASE_URL as string;
+      const fetchUrl = `${url}/events`;
+      const userToken = await auth.currentUser?.getIdToken();
+
+      const response = await fetch(fetchUrl, {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${userToken}`,
+        },
+      });
+
+      const data = await response.json();
+
+      if (response.ok) {
+        // TODO: what should go here?
+        console.log("Next users fetched");
+        return data["data"]
+      }
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
   return (
     <div>
-      <Table columns={eventColumns} rows={dummyRows} />
+      <Table
+        columns={eventColumns}
+        rows={dummyRows}
+        prevFunction={fetchPrevUsers}
+        nextFunction={fetchNextUsers}
+      />
     </div>
   );
 };

--- a/frontend/src/components/organisms/ManageUsers.tsx
+++ b/frontend/src/components/organisms/ManageUsers.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, FormEvent } from "react";
+import React, { ChangeEvent, FormEvent, useEffect } from "react";
 import Table from "@/components/molecules/Table";
 import TabContainer from "@/components/molecules/TabContainer";
 import Button from "../atoms/Button";
@@ -12,7 +12,28 @@ import { BASE_URL } from "@/utils/constants";
 
 interface ManageUsersProps {}
 
-const Active = () => {
+type ActiveProps = {
+  initalRowData: Object[];
+  usersLength: number;
+  initialUserID: string;
+  progressCounter: string;
+  /** The function called to obtain the next elements */
+  progressFunction: (cursor: string) => Promise<
+    | {
+        result: any[];
+        last_user_id: string; // Adjust the type as needed
+      }
+    | undefined
+  >;
+};
+
+const Active = ({
+  initalRowData,
+  usersLength,
+  initialUserID,
+  progressCounter,
+  progressFunction,
+}: ActiveProps) => {
   const eventColumns: GridColDef[] = [
     {
       field: "name",
@@ -83,214 +104,15 @@ const Active = () => {
     },
   ];
 
-  let dummyDate: Date = new Date(2023, 0o1, 21);
-
-  const dummyRows = [
-    {
-      id: 1,
-      name: "Julia Papp",
-      email: "jpapp@gmail.com",
-      role: "Volunteer",
-      date: dummyDate,
-      hours: 20 + " hours",
-    },
-    {
-      id: 2,
-      name: "Julia Papp",
-      email: "jpapp@gmail.com",
-      role: "Volunteer",
-      date: dummyDate,
-      hours: 20 + " hours",
-    },
-    {
-      id: 3,
-      name: "Julia Papp",
-      email: "jpapp@gmail.com",
-      role: "Volunteer",
-      date: dummyDate,
-      hours: 20 + " hours",
-    },
-    {
-      id: 4,
-      name: "Julia Papp",
-      email: "jpapp@gmail.com",
-      role: "Volunteer",
-      date: dummyDate,
-      hours: 20 + " hours",
-    },
-    {
-      id: 5,
-      name: "Julia Papp",
-      email: "jpapp@gmail.com",
-      role: "Volunteer",
-      date: dummyDate,
-      hours: 20 + " hours",
-    },
-    {
-      id: 6,
-      name: "Julia Papp",
-      email: "jpapp@gmail.com",
-      role: "Volunteer",
-      date: dummyDate,
-      hours: 20 + " hours",
-    },
-    {
-      id: 7,
-      name: "Julia Papp",
-      email: "jpapp@gmail.com",
-      role: "Volunteer",
-      date: dummyDate,
-      hours: 20 + " hours",
-    },
-    {
-      id: 8,
-      name: "Julia Papp",
-      email: "jpapp@gmail.com",
-      role: "Volunteer",
-      date: dummyDate,
-      hours: 20 + " hours",
-    },
-    {
-      id: 9,
-      name: "Julia Papp",
-      email: "jpapp@gmail.com",
-      role: "Volunteer",
-      date: dummyDate,
-      hours: 20 + " hours",
-    },
-    {
-      id: 10,
-      name: "Julia Papp",
-      email: "jpapp@gmail.com",
-      role: "Volunteer",
-      date: dummyDate,
-      hours: 20 + " hours",
-    },
-    {
-      id: 11,
-      name: "Julia Papp",
-      email: "jpapp@gmail.com",
-      role: "Volunteer",
-      date: dummyDate,
-      hours: 20 + " hours",
-    },
-    {
-      id: 12,
-      name: "Julia Papp",
-      email: "jpapp@gmail.com",
-      role: "Volunteer",
-      date: dummyDate,
-      hours: 20 + " hours",
-    },
-    {
-      id: 13,
-      name: "Julia Papp",
-      email: "jpapp@gmail.com",
-      role: "Volunteer",
-      date: dummyDate,
-      hours: 20 + " hours",
-    },
-    {
-      id: 14,
-      name: "Julia Papp",
-      email: "jpapp@gmail.com",
-      role: "Volunteer",
-      date: dummyDate,
-      hours: 20 + " hours",
-    },
-    {
-      id: 15,
-      name: "Julia Papp",
-      email: "jpapp@gmail.com",
-      role: "Volunteer",
-      date: dummyDate,
-      hours: 20 + " hours",
-    },
-    {
-      id: 16,
-      name: "Julia Papp",
-      email: "jpapp@gmail.com",
-      role: "Volunteer",
-      date: dummyDate,
-      hours: 20 + " hours",
-    },
-  ];
-
-  // Dummy FETCH function
-  const fetchPrevUsers = async () => {
-    try {
-      const url = BASE_URL as string;
-      const fetchUrl = `${url}/users/`;
-      const userToken = await auth.currentUser?.getIdToken();
-
-      const response = await fetch(fetchUrl, {
-        method: "GET",
-        headers: {
-          Authorization: `Bearer ${userToken}`,
-        },
-      });
-
-      if (response.ok) {
-        // Dummy function placed here just to make sure
-        // front end pagination works
-        const data = await response.json();
-        const clean_data = data["data"];
-        const result = clean_data.map((element: any) => ({
-          id: element["id"],
-          name: element["email"], // problem: the ${url}/users/ request does not provide name
-          email: element["email"],
-          role: element["role"],
-          date: dummyDate,
-          hours: element["hours"] + " hours",
-        }));
-        return result;
-      }
-    } catch (error) {
-      console.log(error);
-    }
-  };
-
-  // Dummy FETCH function
-  const fetchNextUsers = async () => {
-    try {
-      const url = BASE_URL as string;
-      const fetchUrl = `${url}/events`;
-      const userToken = await auth.currentUser?.getIdToken();
-
-      const response = await fetch(fetchUrl, {
-        method: "GET",
-        headers: {
-          Authorization: `Bearer ${userToken}`,
-        },
-      });
-
-      if (response.ok) {
-        // Dummy function placed here just to make sure
-        // front end pagination works
-        const data = await response.json();
-        const clean_data = data["data"];
-        const result = clean_data.map((element: any) => ({
-          id: element["id"],
-          name: element["name"],
-          email: element["location"],
-          role: element["status"],
-          date: dummyDate,
-          hours: 20 + " hours",
-        }));
-        return result;
-      }
-    } catch (error) {
-      console.log(error);
-    }
-  };
-
   return (
     <div>
       <Table
         columns={eventColumns}
-        rowData={dummyRows}
-        prevFunction={fetchPrevUsers}
-        nextFunction={fetchNextUsers}
+        rowData={initalRowData}
+        dataSetLength={usersLength}
+        progressCursor={progressCounter}
+        initialID={initialUserID}
+        nextFunction={progressFunction}
       />
     </div>
   );
@@ -300,9 +122,97 @@ const Active = () => {
  * A ManageUsers component
  */
 const ManageUsers = ({}: ManageUsersProps) => {
+  // the initial rowData
+  const [initialrows, setInitialRows] = React.useState<any[]>([]);
+  const [usersLength, setUsersLength] = React.useState(0);
+  const [initialID, setInitialID] = React.useState("");
+  const [progressCounter, setProgressCounter] = React.useState("");
+  // dummy date
+  let dummyDate: Date = new Date(2023, 0o1, 21);
+
+  const firstUserID_and_usersLength = async () => {
+    const url = BASE_URL as string;
+    try {
+      const fetchUrl = `${url}/users/`;
+      const userToken = await auth.currentUser?.getIdToken();
+      const response = await fetch(fetchUrl, {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${userToken}`,
+        },
+      });
+      if (response.ok) {
+        const data = await response.json();
+
+        const length = data["data"].length;
+        const first_user_id = data["data"][0]["id"];
+        return { length, first_user_id };
+      }
+    } catch (error) {}
+  };
+
+  // Dummy FETCH function
+  const fetchUsers = async (cursor: string) => {
+    const url = BASE_URL as string;
+    const PAGE_SIZE = 6;
+    try {
+      const after = cursor == "" ? "" : `&after=${cursor}`;
+      const fetchUrl = `${url}/users/pagination?limit=${PAGE_SIZE}${after}`;
+      const userToken = await auth.currentUser?.getIdToken();
+      const response = await fetch(fetchUrl, {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${userToken}`,
+        },
+      });
+      if (response.ok) {
+        // Dummy function placed here just to make sure
+        // front end pagination works
+        const data = await response.json();
+        const clean_data = data["data"];
+        const result = clean_data.map((element: any) => ({
+          id: element["id"],
+          name:
+            element["profile"]["firstName"] + element["profile"]["lastName"],
+          email: element["email"],
+          role: element["status"],
+          date: dummyDate,
+          hours: 20 + " hours",
+        }));
+        var last_user_id = result.pop()["id"];
+        setInitialRows(result);
+        setProgressCounter(last_user_id);
+        return { result, last_user_id };
+      }
+    } catch (error) {
+      console.log(error);
+    }
+  };
   const tabs = [
-    { label: "Active", panel: <Active /> },
-    { label: "Blacklisted", panel: <Active /> }, // need to change panel for Blacklisted
+    {
+      label: "Active",
+      panel: (
+        <Active
+          initalRowData={initialrows}
+          usersLength={usersLength}
+          initialUserID={initialID}
+          progressCounter={progressCounter}
+          progressFunction={fetchUsers}
+        />
+      ),
+    },
+    {
+      label: "Blacklisted",
+      panel: (
+        <Active
+          initalRowData={initialrows}
+          usersLength={usersLength}
+          initialUserID={initialID}
+          progressCounter={progressCounter}
+          progressFunction={fetchUsers}
+        />
+      ),
+    }, // need to change panel for Blacklisted
   ];
 
   // Search bar
@@ -313,10 +223,22 @@ const ManageUsers = ({}: ManageUsersProps) => {
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     // Prevent page refresh
     event.preventDefault();
-
     // Actual function
     console.log(value);
   };
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const result = await firstUserID_and_usersLength();
+      if (result != undefined) {
+        await fetchUsers(result.first_user_id);
+        console.log("passed fetch user");
+        setInitialID(result.first_user_id);
+        setUsersLength(result.length);
+      }
+    };
+    fetchData();
+  }, []);
 
   return (
     <>
@@ -329,9 +251,11 @@ const ManageUsers = ({}: ManageUsersProps) => {
           onClick={handleSubmit}
         />
       </div>
-      <div>
-        <TabContainer tabs={tabs} />
-      </div>
+      {initialrows.length > 0 && (
+        <div>
+          <TabContainer tabs={tabs} />
+        </div>
+      )}
     </>
   );
 };

--- a/frontend/src/components/organisms/ManageUsers.tsx
+++ b/frontend/src/components/organisms/ManageUsers.tsx
@@ -16,22 +16,14 @@ type ActiveProps = {
   initalRowData: Object[];
   usersLength: number;
   initialUserID: string;
-  progressCounter: string;
   /** The function called to obtain the next elements */
-  progressFunction: (cursor: string) => Promise<
-    | {
-        result: any[];
-        last_user_id: string; // Adjust the type as needed
-      }
-    | undefined
-  >;
+  progressFunction: (cursor: string) => Promise<any[]>;
 };
 
 const Active = ({
   initalRowData,
   usersLength,
   initialUserID,
-  progressCounter,
   progressFunction,
 }: ActiveProps) => {
   const eventColumns: GridColDef[] = [
@@ -110,7 +102,6 @@ const Active = ({
         columns={eventColumns}
         rowData={initalRowData}
         dataSetLength={usersLength}
-        progressCursor={progressCounter}
         initialID={initialUserID}
         nextFunction={progressFunction}
       />
@@ -126,7 +117,6 @@ const ManageUsers = ({}: ManageUsersProps) => {
   const [initialrows, setInitialRows] = React.useState<any[]>([]);
   const [usersLength, setUsersLength] = React.useState(0);
   const [initialID, setInitialID] = React.useState("");
-  const [progressCounter, setProgressCounter] = React.useState("");
   // dummy date
   let dummyDate: Date = new Date(2023, 0o1, 21);
 
@@ -179,10 +169,8 @@ const ManageUsers = ({}: ManageUsersProps) => {
           date: dummyDate,
           hours: 20 + " hours",
         }));
-        var last_user_id = result.pop()["id"];
-        setInitialRows(result);
-        setProgressCounter(last_user_id);
-        return { result, last_user_id };
+
+        return result;
       }
     } catch (error) {
       console.log(error);
@@ -196,7 +184,6 @@ const ManageUsers = ({}: ManageUsersProps) => {
           initalRowData={initialrows}
           usersLength={usersLength}
           initialUserID={initialID}
-          progressCounter={progressCounter}
           progressFunction={fetchUsers}
         />
       ),
@@ -208,7 +195,6 @@ const ManageUsers = ({}: ManageUsersProps) => {
           initalRowData={initialrows}
           usersLength={usersLength}
           initialUserID={initialID}
-          progressCounter={progressCounter}
           progressFunction={fetchUsers}
         />
       ),
@@ -231,8 +217,9 @@ const ManageUsers = ({}: ManageUsersProps) => {
     const fetchData = async () => {
       const result = await firstUserID_and_usersLength();
       if (result != undefined) {
-        await fetchUsers(result.first_user_id);
+        const final_result = await fetchUsers(result.first_user_id);
         console.log("passed fetch user");
+        setInitialRows(final_result);
         setInitialID(result.first_user_id);
         setUsersLength(result.length);
       }

--- a/frontend/src/components/organisms/ViewEvents.tsx
+++ b/frontend/src/components/organisms/ViewEvents.tsx
@@ -11,7 +11,7 @@ import Button from "../atoms/Button";
 import Link from "next/link";
 
 type Action = "rsvp" | "cancel rsvp" | "publish" | "manage attendees" | "edit";
-
+ 
 const UpcomingEvents = () => {
   return (
     <CardList>


### PR DESCRIPTION
## Summary

<!-- Summarize your changes here. -->
Clicking on the pagination buttons in the MUI Data Grid performs a function/API call instead of initiating the built-in pagination functionality.

## Testing
You'll only need the local host to test this.
On the website navigate to the `Manage Users` tab, then click the pagination buttons to the lower right of the table. You should be able to switch between different users. 


<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->
<img width="914" alt="image" src="https://github.com/cornellh4i/lagos-volunteers/assets/90882246/e72b7007-847f-49cb-a080-4a3ef153cdcb">
<img width="914" alt="image" src="https://github.com/cornellh4i/lagos-volunteers/assets/90882246/00c6c49a-9592-4871-b901-4f2457985c19">

## Notes
I made some changes to the `Table` prop: Notably:
<img width="594" alt="image" src="https://github.com/cornellh4i/lagos-volunteers/assets/90882246/a3438aaf-83e8-4d6c-af39-e0a3f8bc5f04">
 I added `dataSetLength` and `initialID` so that I can have some starting ID to begin the pagination process and a limit to end pagination.
`Next Function` is needed to actually implement pagination and move from one page to the next.
With these new additions it would mean that any component calling the `Table` component would probably need two additional functions. One to obtain the `dataSetLength` and `initialID` and another to act as `Next Function`. This is shown in the `ManageUsers` component.
<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->