### PR TITLE
Revert enums back to uppercase

### DIFF
--- a/backend/prisma/migrations/20240217012742_back_to_uppercase/migration.sql
+++ b/backend/prisma/migrations/20240217012742_back_to_uppercase/migration.sql
@@ -1,0 +1,60 @@
+/*
+  Warnings:
+
+  - The values [Virtual,In_Person] on the enum `EventMode` will be removed. If these variants are still used in the database, this will fail.
+  - The values [Draft,Active,Completed,Canceled] on the enum `EventStatus` will be removed. If these variants are still used in the database, this will fail.
+  - The values [Active,Inactive,Hold] on the enum `UserStatus` will be removed. If these variants are still used in the database, this will fail.
+  - The values [Admin,Volunteer,Supervisor] on the enum `userRole` will be removed. If these variants are still used in the database, this will fail.
+
+*/
+-- AlterEnum
+BEGIN;
+CREATE TYPE "EventMode_new" AS ENUM ('VIRTUAL', 'IN_PERSON');
+ALTER TABLE "Event" ALTER COLUMN "mode" DROP DEFAULT;
+ALTER TABLE "Event" ALTER COLUMN "mode" TYPE "EventMode_new" USING ("mode"::text::"EventMode_new");
+ALTER TYPE "EventMode" RENAME TO "EventMode_old";
+ALTER TYPE "EventMode_new" RENAME TO "EventMode";
+DROP TYPE "EventMode_old";
+ALTER TABLE "Event" ALTER COLUMN "mode" SET DEFAULT 'IN_PERSON';
+COMMIT;
+
+-- AlterEnum
+BEGIN;
+CREATE TYPE "EventStatus_new" AS ENUM ('DRAFT', 'ACTIVE', 'COMPLETED', 'CANCELED');
+ALTER TABLE "Event" ALTER COLUMN "status" DROP DEFAULT;
+ALTER TABLE "Event" ALTER COLUMN "status" TYPE "EventStatus_new" USING ("status"::text::"EventStatus_new");
+ALTER TYPE "EventStatus" RENAME TO "EventStatus_old";
+ALTER TYPE "EventStatus_new" RENAME TO "EventStatus";
+DROP TYPE "EventStatus_old";
+ALTER TABLE "Event" ALTER COLUMN "status" SET DEFAULT 'DRAFT';
+COMMIT;
+
+-- AlterEnum
+BEGIN;
+CREATE TYPE "UserStatus_new" AS ENUM ('ACTIVE', 'INACTIVE', 'HOLD');
+ALTER TABLE "User" ALTER COLUMN "status" DROP DEFAULT;
+ALTER TABLE "User" ALTER COLUMN "status" TYPE "UserStatus_new" USING ("status"::text::"UserStatus_new");
+ALTER TYPE "UserStatus" RENAME TO "UserStatus_old";
+ALTER TYPE "UserStatus_new" RENAME TO "UserStatus";
+DROP TYPE "UserStatus_old";
+ALTER TABLE "User" ALTER COLUMN "status" SET DEFAULT 'ACTIVE';
+COMMIT;
+
+-- AlterEnum
+BEGIN;
+CREATE TYPE "userRole_new" AS ENUM ('ADMIN', 'VOLUNTEER', 'SUPERVISOR');
+ALTER TABLE "User" ALTER COLUMN "role" DROP DEFAULT;
+ALTER TABLE "User" ALTER COLUMN "role" TYPE "userRole_new" USING ("role"::text::"userRole_new");
+ALTER TYPE "userRole" RENAME TO "userRole_old";
+ALTER TYPE "userRole_new" RENAME TO "userRole";
+DROP TYPE "userRole_old";
+ALTER TABLE "User" ALTER COLUMN "role" SET DEFAULT 'VOLUNTEER';
+COMMIT;
+
+-- AlterTable
+ALTER TABLE "Event" ALTER COLUMN "status" SET DEFAULT 'DRAFT',
+ALTER COLUMN "mode" SET DEFAULT 'IN_PERSON';
+
+-- AlterTable
+ALTER TABLE "User" ALTER COLUMN "role" SET DEFAULT 'VOLUNTEER',
+ALTER COLUMN "status" SET DEFAULT 'ACTIVE';

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -18,11 +18,11 @@ model User {
   email     String   @unique
 
   // User info
-  role          userRole?         @default(Volunteer)
+  role          userRole?         @default(VOLUNTEER)
   profile       Profile?
   verified      Boolean?          @default(false)
   hours         Int?              @default(0) //toal hours workd
-  status        UserStatus?       @default(Active)
+  status        UserStatus?       @default(ACTIVE)
   createdEvents Event[]           @relation(name: "EventOwner")
   events        EventEnrollment[]
   preferences   UserPreferences?
@@ -78,8 +78,8 @@ model Event {
   imageURL    String?
   startDate   DateTime
   endDate     DateTime
-  mode        EventMode?        @default(In_Person)
-  status      EventStatus?      @default(Draft)
+  mode        EventMode?        @default(IN_PERSON)
+  status      EventStatus?      @default(DRAFT)
   owner       User              @relation(fields: [ownerId], references: [id], name: "EventOwner")
   ownerId     String
   attendees   EventEnrollment[]
@@ -114,25 +114,25 @@ model EventEnrollment {
 }
 
 enum userRole {
-  Admin
-  Volunteer
-  Supervisor
+  ADMIN
+  VOLUNTEER
+  SUPERVISOR
 }
 
 enum UserStatus {
-  Active
-  Inactive
-  Hold
+  ACTIVE
+  INACTIVE
+  HOLD
 }
 
 enum EventStatus {
-  Draft
-  Active
-  Completed
-  Canceled
+  DRAFT
+  ACTIVE
+  COMPLETED
+  CANCELED
 }
 
 enum EventMode {
-  Virtual
-  In_Person
+  VIRTUAL
+  IN_PERSON
 }

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -68,7 +68,7 @@ async function createPoolOfRandomEvents(pool: number) {
     const createdSupervisor = await prisma.user.create({
       data: {
         email: supervisor.email,
-        role: "Supervisor",
+        role: "SUPERVISOR",
         profile: {
           create: {
             firstName: supervisor.firstName,
@@ -154,7 +154,7 @@ const userData: Prisma.UserCreateInput[] = [
         nickname: "Gracey",
       },
     },
-    role: "Supervisor",
+    role: "SUPERVISOR",
   },
   {
     email: "prisma@hey.com",
@@ -165,7 +165,7 @@ const userData: Prisma.UserCreateInput[] = [
         nickname: "Destiny",
       },
     },
-    role: "Admin",
+    role: "ADMIN",
   },
 ];
 

--- a/backend/src/utils/script.ts
+++ b/backend/src/utils/script.ts
@@ -1,7 +1,7 @@
 // script to seed databse with dummy data
 import { faker } from "@faker-js/faker";
 
-type Role = "Volunteer" | "Admin" | "Supervisor";
+type Role = "VOLUNTEER" | "ADMIN" | "SUPERVISOR";
 
 export interface dummyUser {
   email: string;
@@ -13,8 +13,8 @@ export interface dummyUser {
   phone?: string;
 }
 
-type Mode = "In_Person" | "Virtual";
-type Status = "Draft" | "Active" | "Cancelled" | "Completed";
+type Mode = "IN_PERSON" | "VIRTUAL";
+type Status = "DRAFT" | "ACTIVE" | "CANCELED" | "COMPLETED";
 
 export interface dummyEvent {
   name: string;
@@ -37,9 +37,9 @@ export function createRandomUser(): dummyUser {
   const nickname = faker.person.firstName();
   const phone = faker.phone.number();
   const role = faker.helpers.arrayElement([
-    "Volunteer",
-    "Admin",
-    "Supervisor",
+    "VOLUNTEER",
+    "ADMIN",
+    "SUPERVISOR",
   ]) as Role;
 
   return {
@@ -64,12 +64,12 @@ export function createRandomEvent(): dummyEvent {
   const capacity = faker.number.int({ min: 10, max: 1000 });
   const imageURL = faker.image.urlLoremFlickr({ category: "people" });
   const status = faker.helpers.arrayElement([
-    "Draft",
-    "Active",
-    "Cancelled",
-    "Completed",
+    "DRAFT",
+    "ACTIVE",
+    "CANCELLED",
+    "COMPLETED",
   ]) as Status;
-  const mode = faker.helpers.arrayElement(["In_Person", "Virtual"]) as Mode;
+  const mode = faker.helpers.arrayElement(["IN_PERSON", "VIRTUAL"]) as Mode;
   const tags = faker.lorem.words(3).split(" ");
 
   return {

--- a/backend/tests/events.test.ts
+++ b/backend/tests/events.test.ts
@@ -94,22 +94,6 @@ describe("Testing GET /events/:eventid", () => {
   });
 });
 
-describe("Testing POST /events/:eventid/attendees", () => {
-  test("Add attendee for existing event", async () => {
-    const events = await request(app).get("/events");
-    const users = await request(app).get("/users");
-    const eventid = events.body.data.result[1].id;
-    const attendeeid_1 = users.body.data.result[1].id;
-    const attendee1 = {
-      attendeeid: `${attendeeid_1}`,
-    };
-    const response = await request(app)
-      .post("/events/" + eventid + "/attendees/")
-      .send(attendee1);
-    expect(response.status).toBe(200);
-  });
-});
-
 describe("Testing GET /events/:eventid/attendees", () => {
   test("Get attendees for existing event", async () => {
     const events = await request(app).get("/events");
@@ -126,6 +110,22 @@ describe("Testing GET /events/:eventid/attendees", () => {
       "/events/" + eventid + "/attendees"
     );
     expect(response.body.data.length).toBe(0);
+  });
+});
+
+describe("Testing POST /events/:eventid/attendees", () => {
+  test("Add attendee for existing event", async () => {
+    const events = await request(app).get("/events");
+    const users = await request(app).get("/users");
+    const eventid = events.body.data.result[1].id;
+    const attendeeid_1 = users.body.data.result[1].id;
+    const attendee1 = {
+      attendeeid: `${attendeeid_1}`,
+    };
+    const response = await request(app)
+      .post("/events/" + eventid + "/attendees/")
+      .send(attendee1);
+    expect(response.status).toBe(200);
   });
 });
 

--- a/backend/tests/events.test.ts
+++ b/backend/tests/events.test.ts
@@ -79,6 +79,22 @@ describe("Testing PUT /events/:eventid", () => {
   });
 });
 
+describe("Testing POST /events/:eventid/attendees", () => {
+  test("Add attendee for existing event", async () => {
+    const events = await request(app).get("/events");
+    const users = await request(app).get("/users");
+    const eventid = events.body.data.result[1].id;
+    const attendeeid_1 = users.body.data.result[1].id;
+    const attendee1 = {
+      attendeeid: `${attendeeid_1}`,
+    };
+    const response = await request(app)
+      .post("/events/" + eventid + "/attendees/")
+      .send(attendee1);
+    expect(response.status).toBe(200);
+  });
+});
+
 describe("Testing GET /events/:eventid", () => {
   test("Get existing event", async () => {
     const events = await request(app).get("/events");
@@ -160,22 +176,6 @@ describe("Testing PATCH /events/:eventid/owner", () => {
       .patch("/events/" + eventid + "/owner")
       .send({ ownerid: `${ownerid}` });
     expect(response.status).toBe(500);
-  });
-});
-
-describe("Testing POST /events/:eventid/attendees", () => {
-  test("Add attendee for existing event", async () => {
-    const events = await request(app).get("/events");
-    const users = await request(app).get("/users");
-    const eventid = events.body.data.result[1].id;
-    const attendeeid_1 = users.body.data.result[1].id;
-    const attendee1 = {
-      attendeeid: `${attendeeid_1}`,
-    };
-    const response = await request(app)
-      .post("/events/" + eventid + "/attendees/")
-      .send(attendee1);
-    expect(response.status).toBe(200);
   });
 });
 

--- a/backend/tests/events.test.ts
+++ b/backend/tests/events.test.ts
@@ -137,22 +137,6 @@ describe("Testing PATCH /events/:eventid/status", () => {
   });
 });
 
-describe("Testing POST /events/:eventid/attendees", () => {
-  test("Add attendee for existing event", async () => {
-    const events = await request(app).get("/events");
-    const users = await request(app).get("/users");
-    const eventid = events.body.data.result[1].id;
-    const attendeeid_1 = users.body.data.result[1].id;
-    const attendee1 = {
-      attendeeid: `${attendeeid_1}`,
-    };
-    const response = await request(app)
-      .post("/events/" + eventid + "/attendees/")
-      .send(attendee1);
-    expect(response.status).toBe(200);
-  });
-});
-
 describe("Testing PATCH /events/:eventid/owner", () => {
   test("Change current owner", async () => {
     const events = await request(app).get("/events");
@@ -176,6 +160,22 @@ describe("Testing PATCH /events/:eventid/owner", () => {
       .patch("/events/" + eventid + "/owner")
       .send({ ownerid: `${ownerid}` });
     expect(response.status).toBe(500);
+  });
+});
+
+describe("Testing POST /events/:eventid/attendees", () => {
+  test("Add attendee for existing event", async () => {
+    const events = await request(app).get("/events");
+    const users = await request(app).get("/users");
+    const eventid = events.body.data.result[1].id;
+    const attendeeid_1 = users.body.data.result[1].id;
+    const attendee1 = {
+      attendeeid: `${attendeeid_1}`,
+    };
+    const response = await request(app)
+      .post("/events/" + eventid + "/attendees/")
+      .send(attendee1);
+    expect(response.status).toBe(200);
   });
 });
 

--- a/backend/tests/events.test.ts
+++ b/backend/tests/events.test.ts
@@ -79,6 +79,21 @@ describe("Testing PUT /events/:eventid", () => {
   });
 });
 
+describe("Testing GET /events/:eventid", () => {
+  test("Get existing event", async () => {
+    const events = await request(app).get("/events");
+    const eventid = events.body.data.result[1].id;
+    const response = await request(app).get("/events/" + eventid);
+    expect(response.status).toBe(200);
+  });
+
+  test("Get non-existing event", async () => {
+    const eventid = -1;
+    const response = await request(app).get("/events/" + eventid);
+    expect(response.body.data).toEqual(null);
+  });
+});
+
 describe("Testing POST /events/:eventid/attendees", () => {
   test("Add attendee for existing event", async () => {
     const events = await request(app).get("/events");
@@ -92,21 +107,6 @@ describe("Testing POST /events/:eventid/attendees", () => {
       .post("/events/" + eventid + "/attendees/")
       .send(attendee1);
     expect(response.status).toBe(200);
-  });
-});
-
-describe("Testing GET /events/:eventid", () => {
-  test("Get existing event", async () => {
-    const events = await request(app).get("/events");
-    const eventid = events.body.data.result[1].id;
-    const response = await request(app).get("/events/" + eventid);
-    expect(response.status).toBe(200);
-  });
-
-  test("Get non-existing event", async () => {
-    const eventid = -1;
-    const response = await request(app).get("/events/" + eventid);
-    expect(response.body.data).toEqual(null);
   });
 });
 

--- a/backend/tests/events.test.ts
+++ b/backend/tests/events.test.ts
@@ -117,13 +117,13 @@ describe("Testing PATCH /events/:eventid/status", () => {
   test("Update event status to active", async () => {
     const events = await request(app).get("/events");
     const eventid = events.body.data.result[0].id;
-    const status = "Active";
+    const status = "ACTIVE";
     const response = await request(app)
       .patch(`/events/${eventid}/status`)
       .send({ status: `${status}` });
     const data = response.body.data;
     expect(response.status).toBe(200);
-    expect(data.status).toBe("Active");
+    expect(data.status).toBe("ACTIVE");
   });
 
   test("Event status invalid", async () => {

--- a/backend/tests/events.test.ts
+++ b/backend/tests/events.test.ts
@@ -113,22 +113,6 @@ describe("Testing GET /events/:eventid/attendees", () => {
   });
 });
 
-describe("Testing POST /events/:eventid/attendees", () => {
-  test("Add attendee for existing event", async () => {
-    const events = await request(app).get("/events");
-    const users = await request(app).get("/users");
-    const eventid = events.body.data.result[1].id;
-    const attendeeid_1 = users.body.data.result[1].id;
-    const attendee1 = {
-      attendeeid: `${attendeeid_1}`,
-    };
-    const response = await request(app)
-      .post("/events/" + eventid + "/attendees/")
-      .send(attendee1);
-    expect(response.status).toBe(200);
-  });
-});
-
 describe("Testing PATCH /events/:eventid/status", () => {
   test("Update event status to active", async () => {
     const events = await request(app).get("/events");
@@ -150,6 +134,22 @@ describe("Testing PATCH /events/:eventid/status", () => {
       .patch("/events/" + eventid + "/status")
       .send({ status: status });
     expect(response.status).toBe(500);
+  });
+});
+
+describe("Testing POST /events/:eventid/attendees", () => {
+  test("Add attendee for existing event", async () => {
+    const events = await request(app).get("/events");
+    const users = await request(app).get("/users");
+    const eventid = events.body.data.result[1].id;
+    const attendeeid_1 = users.body.data.result[1].id;
+    const attendee1 = {
+      attendeeid: `${attendeeid_1}`,
+    };
+    const response = await request(app)
+      .post("/events/" + eventid + "/attendees/")
+      .send(attendee1);
+    expect(response.status).toBe(200);
   });
 });
 

--- a/backend/tests/users.test.ts
+++ b/backend/tests/users.test.ts
@@ -14,12 +14,12 @@ describe("Testing POST /users", () => {
   test("POST Create a new user", async () => {
     const user = {
       email: "desi2@gmail.com",
-      role: "Admin",
+      role: "ADMIN",
     };
     const response = await request(app).post("/users").send(user);
     const data = response.body.data;
     expect(data.email).toBe("desi2@gmail.com");
-    expect(data.role).toBe("Admin");
+    expect(data.role).toBe("ADMIN");
 
     expect(response.status).toBe(201);
   });
@@ -54,8 +54,8 @@ describe("Testing PUT /users/:userid/profile", () => {
   test("edit a user's profile with an existing and not existing fields", async () => {
     const user = {
       email: "testeditprof@gmail.com",
-      role: "Admin",
-      status: "Active",
+      role: "ADMIN",
+      status: "ACTIVE",
       hours: 0,
       profile: {
         firstName: "Arizona",
@@ -123,9 +123,9 @@ describe("Testing PATCH /users/:userid/role", () => {
     const userid = users.body.data.result[9].id;
     const response = await request(app)
       .patch("/users/" + userid + "/role")
-      .send({ role: "Supervisor" });
+      .send({ role: "SUPERVISOR" });
     const data = response.body.data;
-    expect(data.role).toBe("Supervisor");
+    expect(data.role).toBe("SUPERVISOR");
     expect(response.status).toBe(200);
   });
 });
@@ -137,9 +137,9 @@ describe("Testing PATCH /users/:userid/status", () => {
     const userid = users.body.data.result[9].id;
     const response = await request(app)
       .patch("/users/" + userid + "/status")
-      .send({ status: "Inactive" });
+      .send({ status: "INACTIVE" });
     const data = response.body.data;
-    expect(data.status).toBe("Inactive");
+    expect(data.status).toBe("INACTIVE");
     expect(response.status).toBe(200);
   });
 });
@@ -159,8 +159,8 @@ describe("Testing PATCH /users/:userid/hours", () => {
 });
 
 describe("Testing /users/search", () => {
-  test("GET users with status=Active", async () => {
-    const response = await request(app).get("/users/search?status=Active");
+  test("GET users with status=ACTIVE", async () => {
+    const response = await request(app).get("/users/search?status=ACTIVE");
     expect(response.status).toBe(200);
   });
 
@@ -173,11 +173,11 @@ describe("Testing /users/search", () => {
     expect(response.status).toBe(200);
   });
 
-  test("GET users with role=Admin", async () => {
-    const response = await request(app).get("/users/search?role=Admin");
+  test("GET users with role=ADMIN", async () => {
+    const response = await request(app).get("/users/search?role=ADMIN");
     const data = response.body.data;
     for (let i = 0; i < data.length; i++) {
-      expect(data[i].role).toBe("Admin");
+      expect(data[i].role).toBe("ADMIN");
     }
     expect(response.status).toBe(200);
   });
@@ -205,16 +205,16 @@ describe("Testing /users/search", () => {
     expect(response.status).toBe(200);
   });
 
-  test("GET users with hours=0&firstName=Alice&status=Active", async () => {
+  test("GET users with hours=0&firstName=Alice&status=ACTIVE", async () => {
     const response = await request(app).get(
-      "/users/search?hours=0&firstName=Alice&status=Active"
+      "/users/search?hours=0&firstName=Alice&status=ACTIVE"
     );
     const data = response.body.data;
 
     for (let i = 0; i < data.length; i++) {
       expect(data[i].hours).toBe(0);
       expect(data[i].profile.firstName).toBe("Alice");
-      expect(data[i].status).toBe("Active");
+      expect(data[i].status).toBe("ACTIVE");
     }
     expect(response.status).toBe(200);
   });

--- a/frontend/src/components/organisms/EventCardNew.tsx
+++ b/frontend/src/components/organisms/EventCardNew.tsx
@@ -20,11 +20,11 @@ const EventCardContent = ({ event }: EventCardNewProps) => {
   const date = new Date(event.startDate);
   const dateInfo = displayDateInfo(date);
   const url =
-    event.role === "Supervisor"
+    event.role === "SUPERVISOR"
       ? `/events/${event.id}/attendees`
       : `/events/${event.id}/register`;
   const buttonText =
-    event.role === "Supervisor" ? "Manage Event" : "View Event Details";
+    event.role === "SUPERVISOR" ? "Manage Event" : "View Event Details";
 
   return (
     <div>

--- a/frontend/src/components/organisms/EventForm.tsx
+++ b/frontend/src/components/organisms/EventForm.tsx
@@ -59,7 +59,7 @@ const EventForm = ({ eventId, eventType, eventDetails }: EventFormProps) => {
   // For deciding whether to show "In-person" or "Virtual"
   // 0: no show, 1: show yes.
   const [status, setStatus] = React.useState(
-    eventDetails ? (eventDetails.mode === "In_Person" ? 1 : 0) : 0
+    eventDetails ? (eventDetails.mode === "IN_PERSON" ? 1 : 0) : 0
   );
   const radioHandler = (status: number) => {
     setStatus(status);
@@ -119,7 +119,7 @@ const EventForm = ({ eventId, eventType, eventDetails }: EventFormProps) => {
   /** Tanstack mutation for creating a new event */
   const { mutateAsync, isPending, isError, isSuccess } = useMutation({
     mutationFn: async (data: FormValues) => {
-      const mode = status === 0 ? "Virtual" : "In_Person";
+      const mode = status === 0 ? "VIRTUAL" : "IN_PERSON";
       const {
         eventName,
         location,
@@ -137,7 +137,7 @@ const EventForm = ({ eventId, eventType, eventDetails }: EventFormProps) => {
         userID: `${userid}`,
         event: {
           name: `${eventName}`,
-          location: status === 0 ? "Virtual" : `${location}`,
+          location: status === 0 ? "VIRTUAL" : `${location}`,
           description: `${eventDescription}`,
           startDate: new Date(startDateTime),
           endDate: new Date(endDateTime),
@@ -159,7 +159,7 @@ const EventForm = ({ eventId, eventType, eventDetails }: EventFormProps) => {
   /** Tanstack mutation for updating an existing event */
   const { mutateAsync: editEvent, isPending: editEventPending } = useMutation({
     mutationFn: async (data: FormValues) => {
-      const mode = status === 0 ? "Virtual" : "In_Person";
+      const mode = status === 0 ? "VIRTUAL" : "IN_PERSON";
       const { startTime, startDate, endTime, endDate } = getValues();
       const startDateTime = convertToISO(startTime, startDate);
       const endDateTime = convertToISO(endTime, endDate);

--- a/frontend/src/components/organisms/ManageUserProfile.tsx
+++ b/frontend/src/components/organisms/ManageUserProfile.tsx
@@ -78,7 +78,7 @@ const ModalBody = ({ status, blacklistFunc, handleClose }: modalBodyProps) => {
   return (
     <div>
       <Box sx={{ textAlign: "center", marginBottom: 3 }}>
-        {status == "Active"
+        {status == "ACTIVE"
           ? "Are you sure you want to blacklist this user?"
           : "Are you sure you want to remove this member from the blacklist?"}
       </Box>
@@ -90,7 +90,7 @@ const ModalBody = ({ status, blacklistFunc, handleClose }: modalBodyProps) => {
         </Grid>
         <Grid item md={6} xs={12}>
           <Button variety="error" onClick={blacklistFunc}>
-            {status == "Active" ? "Yes, blacklist" : "Remove"}
+            {status == "ACTIVE" ? "Yes, blacklist" : "Remove"}
           </Button>
         </Grid>
       </Grid>
@@ -136,7 +136,7 @@ const Status = ({
   /** Tanstack query mutation for changing user status */
   const { mutateAsync: changeUserStatus } = useMutation({
     mutationFn: async () => {
-      const status = userStatus == "Active" ? "Inactive" : "Active";
+      const status = userStatus == "ACTIVE" ? "Inactive" : "Active";
       const { data } = await api.patch(`/users/${userID}/status`, {
         status: status,
       });
@@ -176,16 +176,16 @@ const Status = ({
               changeUserRole({ role: event.target.value })
             }
           >
-            <MenuItem value="Volunteer">Volunteer</MenuItem>
-            <MenuItem value="Supervisor">Supervisor</MenuItem>
-            <MenuItem value="Admin">Admin</MenuItem>
+            <MenuItem value="VOLUNTEER">Volunteer</MenuItem>
+            <MenuItem value="SUPERVISOR">Supervisor</MenuItem>
+            <MenuItem value="ADMIN">Admin</MenuItem>
           </Select>
         </FormControl>
 
         <div className="pt-2">Blacklist</div>
         <div className="w-full sm:w-1/4">
           <Button onClick={handleOpen}>
-            {userStatus == "Active"
+            {userStatus == "ACTIVE"
               ? "Blacklist Member"
               : "Remove Member from Blacklist"}
           </Button>

--- a/frontend/src/components/organisms/ManageUserProfileNew.tsx
+++ b/frontend/src/components/organisms/ManageUserProfileNew.tsx
@@ -16,6 +16,7 @@ import { SelectChangeEvent } from "@mui/material/Select";
 import { Box, Grid } from "@mui/material";
 import Modal from "../molecules/Modal";
 import Snackbar from "../atoms/Snackbar";
+import { formatRoleOrStatus } from "@/utils/helpers";
 
 type userProfileData = {
   name: string;
@@ -285,7 +286,7 @@ const ManageUserProfileNew = () => {
         variety="success"
       >
         {`Success: ${name} is now ${
-          role === "ADMIN" ? ` an ${role}` : ` a ${role}`
+          role === "ADMIN" ? ` an ${formatRoleOrStatus(role)}` : ` a ${formatRoleOrStatus(role)}`
         }`}
       </Snackbar>
 
@@ -329,7 +330,7 @@ const ManageUserProfileNew = () => {
       <div className="grid gap-4 md:grid-cols-2">
         <Card>
           <h3 className="mb-2 mt-0">
-            {name} is {role === "ADMIN" ? ` an ${role}` : ` a ${role}`}
+            {name} is {role === "ADMIN" ? "an Admin" : `a ${formatRoleOrStatus(role)}`}
           </h3>
           <div className="mb-4">
             This member currently has {hours} hours of volunteer experience.

--- a/frontend/src/components/organisms/ManageUserProfileNew.tsx
+++ b/frontend/src/components/organisms/ManageUserProfileNew.tsx
@@ -79,7 +79,7 @@ const ModalBody = ({ status, blacklistFunc, handleClose }: modalBodyProps) => {
   return (
     <div>
       <Box sx={{ textAlign: "center", marginBottom: 3 }}>
-        {status == "Active"
+        {status == "ACTIVE"
           ? "Are you sure you want to blacklist this user?"
           : "Are you sure you want to remove this member from the blacklist?"}
       </Box>
@@ -91,7 +91,7 @@ const ModalBody = ({ status, blacklistFunc, handleClose }: modalBodyProps) => {
         </Grid>
         <Grid item md={6} xs={12}>
           <Button variety="secondary" onClick={blacklistFunc}>
-            {status == "Active" ? "Yes, blacklist" : "Yes, Remove"}
+            {status == "ACTIVE" ? "Yes, blacklist" : "Yes, Remove"}
           </Button>
         </Grid>
       </Grid>
@@ -240,7 +240,7 @@ const ManageUserProfileNew = () => {
   /** Tanstack query mutation for changing user status */
   const { mutateAsync: changeUserStatus } = useMutation({
     mutationFn: async () => {
-      const status2Change = status == "Active" ? "Inactive" : "Active";
+      const status2Change = status == "ACTIVE" ? "INACTIVE" : "ACTIVE";
       const { data } = await api.patch(`/users/${userid}/status`, {
         status: status2Change,
       });
@@ -285,7 +285,7 @@ const ManageUserProfileNew = () => {
         variety="success"
       >
         {`Success: ${name} is now ${
-          role === "Admin" ? ` an ${role}` : ` a ${role}`
+          role === "ADMIN" ? ` an ${role}` : ` a ${role}`
         }`}
       </Snackbar>
 
@@ -305,7 +305,7 @@ const ManageUserProfileNew = () => {
         variety="success"
       >
         {`Success: ${name} is now ${
-          status === "Active" ? ` an active ` : ` a blacklisted `
+          status === "ACTIVE" ? ` an active ` : ` a blacklisted `
         } member`}
       </Snackbar>
 
@@ -329,7 +329,7 @@ const ManageUserProfileNew = () => {
       <div className="grid gap-4 md:grid-cols-2">
         <Card>
           <h3 className="mb-2 mt-0">
-            {name} is {role === "Admin" ? ` an ${role}` : ` a ${role}`}
+            {name} is {role === "ADMIN" ? ` an ${role}` : ` a ${role}`}
           </h3>
           <div className="mb-4">
             This member currently has {hours} hours of volunteer experience.
@@ -341,22 +341,22 @@ const ManageUserProfileNew = () => {
               changeUserRole({ role: event.target.value })
             }
           >
-            <MenuItem value="Volunteer">Volunteer</MenuItem>
-            <MenuItem value="Supervisor">Supervisor</MenuItem>
-            <MenuItem value="Admin">Admin</MenuItem>
+            <MenuItem value="VOLUNTEER">Volunteer</MenuItem>
+            <MenuItem value="SUPERVISOR">Supervisor</MenuItem>
+            <MenuItem value="ADMIN">Admin</MenuItem>
           </Select>
         </Card>
         <Card>
           <h3 className="mb-2 mt-0">
-            {name} is {status === "Active" ? ` an Active ` : ` a Blacklisted `}
+            {name} is {status === "ACTIVE" ? ` an Active ` : ` a Blacklisted `}
             member
           </h3>
           <div className="mb-4">
-            {status === "Active"
+            {status === "ACTIVE"
               ? "Would you like to blacklist this member? This will stop them from registering for and attending future events."
               : "Would you like to remove this member from the blacklist?"}
           </div>
-          {status === "Active" ? (
+          {status === "ACTIVE" ? (
             <Button variety="error" onClick={handleOpen}>
               Blacklist
             </Button>

--- a/frontend/src/components/organisms/ManageUsers.tsx
+++ b/frontend/src/components/organisms/ManageUsers.tsx
@@ -11,6 +11,7 @@ import { api } from "@/utils/api";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import Loading from "@/components/molecules/Loading";
 import Card from "../molecules/Card";
+import { formatRoleOrStatus } from "@/utils/helpers";
 
 interface ManageUsersProps {}
 
@@ -186,7 +187,7 @@ const ManageUsers = ({}: ManageUsersProps) => {
       id: user.id,
       name: user.profile?.firstName + " " + user.profile?.lastName,
       email: user.email,
-      role: user.status,
+      role: formatRoleOrStatus(user.role),
       date: new Date(formatDateString(user.createdAt)),
       hours: user.hours, // TODO: properly calculate hours
     });

--- a/frontend/src/pages/profile.tsx
+++ b/frontend/src/pages/profile.tsx
@@ -44,12 +44,12 @@ const Profile = () => {
         {/* TODO: this string parsing stuff is really really ugly right now
         and should absolutely be refactored into something sane ASAP */}
         <h3 className="mt-0 mb-2 font-normal">
-          You are {data?.role === "Admin" ? "an " : "a "}
+          You are {data?.role === "ADMIN" ? "an " : "a "}
           <span className="font-bold">{data?.role}</span>
         </h3>
         You are currently{" "}
-        {data?.role === "Admin" ? "an Admin" : `a ${data?.role}`}.{" "}
-        {data?.role === "Admin" ? "An Admin" : `A ${data?.role}`} is allowed to
+        {data?.role === "ADMIN" ? "an Admin" : `a ${data?.role}`}.{" "}
+        {data?.role === "ADMIN" ? "An Admin" : `A ${data?.role}`} is allowed to
         register for and attend events.
       </Card>
       <Card>
@@ -58,7 +58,7 @@ const Profile = () => {
         </h3>
         You are currently an {data?.status.toLowerCase()} member. Your account
         is {data?.status.toLowerCase()} and you are{" "}
-        {data?.status === "Active" ? "able to" : "not able to"} access all
+        {data?.status === "ACTIVE" ? "able to" : "not able to"} access all
         normal website functions.
       </Card>
       <h3 className="text-xl font-normal">My Profile</h3>

--- a/frontend/src/pages/profile.tsx
+++ b/frontend/src/pages/profile.tsx
@@ -9,6 +9,7 @@ import { api } from "@/utils/api";
 import { useQuery } from "@tanstack/react-query";
 import Loading from "@/components/molecules/Loading";
 import Error from "@/components/organisms/Error";
+import { formatRoleOrStatus } from "@/utils/helpers";
 
 /** A Profile page */
 const Profile = () => {
@@ -31,6 +32,7 @@ const Profile = () => {
   // TODO: make better
   if (isError) return <Error />;
 
+
   return (
     <CenteredTemplate>
       <Avatar
@@ -45,16 +47,16 @@ const Profile = () => {
         and should absolutely be refactored into something sane ASAP */}
         <h3 className="mt-0 mb-2 font-normal">
           You are {data?.role === "ADMIN" ? "an " : "a "}
-          <span className="font-bold">{data?.role}</span>
+          <span className="font-bold">{formatRoleOrStatus(data.role)}</span>
         </h3>
         You are currently{" "}
-        {data?.role === "ADMIN" ? "an Admin" : `a ${data?.role}`}.{" "}
-        {data?.role === "ADMIN" ? "An Admin" : `A ${data?.role}`} is allowed to
+        {data?.role === "ADMIN" ? "an Admin" : `a ${data?.role.toLowerCase()}`}.{" "}
+        {data?.role === "ADMIN" ? "An Admin" : `A ${formatRoleOrStatus(data?.role)}`} is allowed to
         register for and attend events.
       </Card>
       <Card>
         <h3 className="mt-0 mb-2 font-normal">
-          You are an <span className="font-bold">{data?.status} Member</span>
+          You are an <span className="font-bold">{formatRoleOrStatus(data?.status)} Member</span>
         </h3>
         You are currently an {data?.status.toLowerCase()} member. Your account
         is {data?.status.toLowerCase()} and you are{" "}

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -184,3 +184,13 @@ export const displayDateInfo = (date: Date) => {
     return "Upcoming";
   }
 };
+
+/**
+ * Formats the first character of a string to uppercase and the rest to lowercase.
+ * 
+ * @param str - The string to be formatted.
+ * @returns The formatted string.
+ */
+export const formatRoleOrStatus = (str: string) => {
+    return str[0]+str.substring(1).toLowerCase();
+  }

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -187,10 +187,9 @@ export const displayDateInfo = (date: Date) => {
 
 /**
  * Formats the first character of a string to uppercase and the rest to lowercase.
- * 
  * @param str - The string to be formatted.
  * @returns The formatted string.
  */
 export const formatRoleOrStatus = (str: string) => {
-    return str[0]+str.substring(1).toLowerCase();
-  }
+  return str[0] + str.substring(1).toLowerCase();
+};

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -39,13 +39,13 @@ export type EventDTO = {
   capacity: number;
 };
 
-export type EventMode = "Virtual" | "In_Person";
+export type EventMode = "VIRTUAL" | "IN_PERSON";
 
-export type EventStatus = "Active" | "COMPLETED" | "Canceled";
+export type EventStatus = "DRAFT" | "COMPLETED" | "CANCELED";
 
-export type UserStatus = "Active" | "Inactive" | "Hold";
+export type UserStatus = "ACTIVE" | "INACTIVE" | "HOLD";
 
-export type UserRole = "Volunteer" | "Supervisor" | "Admin";
+export type UserRole = "VOLUNTEER" | "SUPERVISOR" | "ADMIN";
 
 export type Action =
   | "rsvp"


### PR DESCRIPTION
## Summary

changing to sentence case enums was shortsighted. Apologies for the headache and here's my chance at redemption. 

## Testing

I have clicked through the website. I tried changing user roles, statuses and the likes. Also tried create a new event to see if it still works. Everything works fine. For good measure, I looked into the 2 commits, I used to initially change it to sentence case and tried to make sure I undid everything. ran all the tests locally. Everything works fine so far, including seeding. 