### PR TITLE
Fix Tailwind not applying to MUI components

### DIFF
--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -6,6 +6,8 @@ import Layout from "@/components/Layout";
 import { AuthProvider } from "@/utils/AuthContext";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
+const rootElement = () => document.getElementById("__next");
+
 export const theme = createTheme({
   typography: {
     fontFamily: "Inter, sans-serif",
@@ -29,6 +31,28 @@ export const theme = createTheme({
     },
     background: {
       default: "#FFFFFF",
+    },
+  },
+  components: {
+    MuiPopover: {
+      defaultProps: {
+        container: rootElement,
+      },
+    },
+    MuiPopper: {
+      defaultProps: {
+        container: rootElement,
+      },
+    },
+    MuiDialog: {
+      defaultProps: {
+        container: rootElement,
+      },
+    },
+    MuiModal: {
+      defaultProps: {
+        container: rootElement,
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary

Tailwind CSS never used to apply to MUI components like modal bodies. Now it does! You're welcome.

## Testing

Open `EventCardCancel.tsx` and add some Tailwind CSS styling to the modal body.

## Notes

Followed the steps in this Stack Overflow article:
https://stackoverflow.com/questions/73810671/tailwind-style-doesnt-seems-to-be-apply-inside-material-ui-drawer-component-in