### PR TITLE
Replace yarn build with yarn setup

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -27,13 +27,13 @@
     "typescript": "^4.9.4"
   },
   "scripts": {
-    "build": "yarn install && npx prisma migrate dev && yarn prisma db seed && yarn swagger",
-    "test": "yarn run build && NODE_ENV=test jest",
+    "setup": "yarn install && npx prisma migrate dev && yarn prisma db seed && yarn swagger",
+    "test": "yarn run setup && NODE_ENV=test jest",
     "test:ci": "NODE_ENV=test prisma db seed && jest -i",
     "start": "npx prisma studio & yarn run backend",
     "backend": "nodemon -r dotenv/config src/index.ts",
     "swagger": "ts-node -r dotenv/config src/swagger.ts",
-    "build:local": "tsc",
+    "build": "tsc",
     "start:local": "ts-node -r dotenv/config src/index.ts"
   },
   "prisma": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,10 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build": "yarn install",
+    "setup": "yarn install",
     "start": "yarn run dev",
     "dev": "next dev",
-    "build:local": "next build",
+    "build": "next build",
     "start:local": "next start",
     "lint:local": "next lint"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build": "(cd backend && yarn run build) && (cd frontend && yarn run build)",
+    "setup": "(cd backend && yarn run setup) && (cd frontend && yarn run setup)",
     "test": "cd backend && yarn run test",
     "start": "(cd backend && yarn run start) & (cd frontend && yarn run start)"
   }


### PR DESCRIPTION
## Summary

`yarn build` is overloaded, replace with `yarn setup` so that `yarn build` is just for deployment
