### PR TITLE
Allow dynamic modal height

### DIFF
--- a/frontend/src/components/molecules/Modal.tsx
+++ b/frontend/src/components/molecules/Modal.tsx
@@ -20,7 +20,7 @@ const style = {
 
 const styleSmall = {
   overflow: "scroll",
-  height: "80%",
+  maxHeight: "80%",
   width: "80%",
   padding: 4,
   display: { xs: "block", md: "none" },
@@ -28,7 +28,7 @@ const styleSmall = {
 
 const styleLarge = {
   overflow: "scroll",
-  height: "80%",
+  maxHeight: "80%",
   width: 500,
   padding: "4rem 6rem",
   display: { xs: "none", md: "block" },


### PR DESCRIPTION
## Summary

PR #165 introduced a regression which forced all modal bodies to be the 80% height. This changes it to be a maxHeight param instead.

## Testing

Same as #165.