### PR TITLE
Stop prisma studio from autostarting in browser

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -30,7 +30,7 @@
     "setup": "yarn install && npx prisma migrate dev && yarn prisma db seed && yarn swagger",
     "test": "yarn run setup && NODE_ENV=test jest",
     "test:ci": "NODE_ENV=test prisma db seed && jest -i",
-    "start": "npx prisma studio & yarn run backend",
+    "start": "npx prisma studio --browser none & yarn run backend",
     "backend": "nodemon -r dotenv/config src/index.ts",
     "swagger": "ts-node -r dotenv/config src/swagger.ts",
     "build": "tsc",


### PR DESCRIPTION
## Summary

prisma studio currently always opens when you type `yarn start`. This can be annoying. This changes it so that prisma studio is still started but doesn't automatically open in a tab.

## Testing

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

## Notes

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->