### PR TITLE
Implement skeleton for websockets

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -10,6 +10,7 @@
     "@types/jest": "^29.5.12",
     "@types/node": "^20.11.16",
     "@types/swagger-ui-express": "^4.1.6",
+    "@types/ws": "^8.5.10",
     "body-parser": "^1.20.2",
     "cors": "^2.8.5",
     "date-fns": "^3.3.1",
@@ -25,7 +26,8 @@
     "swagger-ui-express": "^5.0.0",
     "ts-jest": "^29.1.2",
     "ts-node": "^10.9.2",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "ws": "^8.16.0"
   },
   "scripts": {
     "setup": "yarn install && npx prisma migrate dev && yarn prisma db seed && yarn swagger",

--- a/backend/src/events/views.ts
+++ b/backend/src/events/views.ts
@@ -1,7 +1,7 @@
 import { Router, RequestHandler, Request, Response } from "express";
 import eventController from "./controllers";
 import { auth } from "../middleware/auth";
-import { attempt } from "../utils/helpers";
+import { attempt, socketNotify } from "../utils/helpers";
 
 import { errorJson, successJson } from "../utils/jsonResponses";
 import { EventMode, EventStatus, Prisma } from "@prisma/client";
@@ -33,6 +33,7 @@ eventRouter.post("/", async (req: Request, res: Response) => {
   // #swagger.tags = ['Events']
   const eventDTO: EventDTO = req.body;
   attempt(res, 201, () => eventController.createEvent(eventDTO));
+  socketNotify("/events");
 });
 
 eventRouter.put("/:eventid", async (req: Request, res: Response) => {
@@ -40,11 +41,13 @@ eventRouter.put("/:eventid", async (req: Request, res: Response) => {
   attempt(res, 200, () =>
     eventController.updateEvent(req.params.eventid, req.body)
   );
+  socketNotify(`/events/${req.params.eventid}`);
 });
 
 eventRouter.delete("/:eventid", async (req: Request, res: Response) => {
   // #swagger.tags = ['Events']
   attempt(res, 200, () => eventController.deleteEvent(req.params.eventid));
+  socketNotify("/events");
 });
 
 eventRouter.get("/", async (req: Request, res: Response) => {
@@ -104,6 +107,7 @@ eventRouter.post("/:eventid/attendees", async (req: Request, res: Response) => {
   attempt(res, 200, () =>
     eventController.addAttendee(req.params.eventid, attendeeid)
   );
+  socketNotify(`/events/${req.params.eventid}`);
 });
 
 eventRouter.put("/:eventid/attendees", async (req: Request, res: Response) => {
@@ -116,6 +120,7 @@ eventRouter.put("/:eventid/attendees", async (req: Request, res: Response) => {
       cancelationMessage
     )
   );
+  socketNotify(`/events/${req.params.eventid}`);
 });
 
 eventRouter.patch("/:eventid/status", async (req: Request, res: Response) => {
@@ -124,6 +129,7 @@ eventRouter.patch("/:eventid/status", async (req: Request, res: Response) => {
   attempt(res, 200, () =>
     eventController.updateEventStatus(req.params.eventid, status)
   );
+  socketNotify(`/events/${req.params.eventid}`);
 });
 
 eventRouter.patch("/:eventid/owner", async (req: Request, res: Response) => {
@@ -141,6 +147,7 @@ eventRouter.patch(
     attempt(res, 200, () =>
       eventController.confirmUser(req.params.eventid, req.params.attendeeid)
     );
+    socketNotify(`/events/${req.params.eventid}`);
   }
 );
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -4,15 +4,18 @@ import sgMail from "@sendgrid/mail";
 import { WebSocketServer } from "ws";
 
 // WebSocket server
-const wss = new WebSocketServer({ port: 8080 });
-wss.on("connection", function connection(ws) {
+export const wss = new WebSocketServer({ port: 8080 });
+wss.on("connection", (ws) => {
+  // Error handling
   ws.on("error", console.error);
 
-  ws.on("message", function message(data) {
+  // What happens when the server receives data
+  ws.on("message", (data) => {
     console.log("received: %s", data);
     ws.send("server received your message!");
   });
 
+  // Default message to send when connected
   ws.send("something");
 });
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,7 +1,22 @@
 import app from "./server";
 import admin from "firebase-admin";
 import sgMail from "@sendgrid/mail";
+import { WebSocketServer } from "ws";
 
+// WebSocket server
+const wss = new WebSocketServer({ port: 8080 });
+wss.on("connection", function connection(ws) {
+  ws.on("error", console.error);
+
+  ws.on("message", function message(data) {
+    console.log("received: %s", data);
+    ws.send("server received your message!");
+  });
+
+  ws.send("something");
+});
+
+// Express server
 const server = app.listen(process.env.PORT || 8000);
 
 const serviceAccount = {

--- a/backend/src/users/views.ts
+++ b/backend/src/users/views.ts
@@ -4,8 +4,7 @@ import userController from "./controllers";
 import { auth, setVolunteerCustomClaims, NoAuth } from "../middleware/auth";
 const userRouter = Router();
 import * as firebase from "firebase-admin";
-
-import { attempt } from "../utils/helpers";
+import { attempt, socketNotify } from "../utils/helpers";
 
 let useAuth: RequestHandler;
 
@@ -18,6 +17,7 @@ userRouter.post(
   NoAuth as RequestHandler,
   async (req: Request, res: Response) => {
     // #swagger.tags = ['Users']
+    socketNotify("/users");
     let user;
     const { password, ...rest } = req.body;
     try {
@@ -70,13 +70,17 @@ userRouter.post(
 userRouter.delete("/:userid", useAuth, async (req: Request, res: Response) => {
   // #swagger.tags = ['Users']
   attempt(res, 200, () => userController.deleteUser(req.params.userid));
+  socketNotify("/users");
 });
 
 userRouter.put("/:userid", useAuth, async (req: Request, res: Response) => {
   // #swagger.tags = ['Users']
+
+  // Do API call
   attempt(res, 200, () =>
     userController.updateUser(req.params.userid, req.body)
   );
+  socketNotify(`/users/${req.params.userid}`);
 });
 
 userRouter.get("/count", useAuth, async (req: Request, res: Response) => {
@@ -216,6 +220,7 @@ userRouter.put(
     attempt(res, 200, () =>
       userController.editProfile(req.params.userid, req.body)
     );
+    socketNotify(`/users/${req.params.userid}`);
   }
 );
 
@@ -227,6 +232,7 @@ userRouter.put(
     attempt(res, 200, () =>
       userController.editPreferences(req.params.userid, req.body)
     );
+    socketNotify(`/users/${req.params.userid}`);
   }
 );
 
@@ -234,6 +240,7 @@ userRouter.patch("/:userid/status", async (req: Request, res: Response) => {
   // #swagger.tags = ['Users']
   const { status } = req.body;
   attempt(res, 200, () => userController.editStatus(req.params.userid, status));
+  socketNotify(`/users/${req.params.userid}`);
 });
 
 userRouter.patch(
@@ -243,6 +250,7 @@ userRouter.patch(
     // #swagger.tags = ['Users']
     const { role } = req.body;
     attempt(res, 200, () => userController.editRole(req.params.userid, role));
+    socketNotify(`/users/${req.params.userid}`);
   }
 );
 
@@ -253,6 +261,7 @@ userRouter.patch(
     // #swagger.tags = ['Users']
     const { hours } = req.body;
     attempt(res, 200, () => userController.editHours(req.params.userid, hours));
+    socketNotify(`/users/${req.params.userid}`);
   }
 );
 

--- a/backend/src/utils/helpers.ts
+++ b/backend/src/utils/helpers.ts
@@ -1,5 +1,7 @@
 import { Response } from "express";
 import { errorJson, successJson } from "./jsonResponses";
+import { WebSocket } from "ws";
+import { wss } from "..";
 
 /**
  * Attempts the given controller and sends a success code or error code as necessary
@@ -16,4 +18,21 @@ export const attempt = async (
   } catch (error: any) {
     res.status(500).send(errorJson(error.message));
   }
+};
+
+/**
+ * Sends a message from the WebSocket server to all WebSocket-connected clients
+ * @param resource is the API resource endpoint that has been updated. For example,
+ * if a specific user with uuid "1234" was updated, the resource would be "/users/1234"
+ */
+export const socketNotify = (resource: string) => {
+  const dataToSend = {
+    resource: resource,
+    message: "The resource has been updated!",
+  };
+  wss.clients.forEach((client) => {
+    if (client.readyState === WebSocket.OPEN) {
+      client.send(JSON.stringify(dataToSend));
+    }
+  });
 };

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -1099,6 +1099,13 @@
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.5.tgz#cb6e2a691b70cb177c6e3ae9c1d2e8b2ea8cd304"
   integrity sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==
 
+"@types/ws@^8.5.10":
+  version "8.5.10"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.10.tgz#4acfb517970853fa6574a3a6886791d04a396787"
+  integrity sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==
+  dependencies:
+    "@types/node" "*"
+
 "@types/yargs-parser@*":
   version "21.0.3"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.3.tgz#815e30b786d2e8f0dcd85fd5bcf5e1a04d008f15"
@@ -3972,6 +3979,11 @@ write-file-atomic@^4.0.2:
   dependencies:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"
+
+ws@^8.16.0:
+  version "8.16.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.16.0.tgz#d1cd774f36fbc07165066a60e40323eab6446fd4"
+  integrity sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==
 
 y18n@^5.0.5:
   version "5.0.8"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,6 +37,7 @@
     "react-hook-form": "^7.50.1",
     "react-html-parser": "^2.0.2",
     "react-quill": "^2.0.0",
+    "react-use-websocket": "^4.8.1",
     "typescript": "^5.3.3"
   },
   "devDependencies": {

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -1,3 +1,4 @@
 export const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL as string;
+export const BASE_WEBSOCKETS_URL = process.env.NEXT_PUBLIC_BASE_WEBSOCKETS_URL;
 export const BASE_URL_CLIENT = process.env
   .NEXT_PUBLIC_BASE_URL_CLIENT as string;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3317,6 +3317,11 @@ react-transition-group@^4.4.5:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
+react-use-websocket@^4.8.1:
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/react-use-websocket/-/react-use-websocket-4.8.1.tgz#be06a0bc956c6d56391a29cbe2caa6ae8edb5615"
+  integrity sha512-FTXuG5O+LFozmu1BRfrzl7UIQngECvGJmL7BHsK4TYXuVt+mCizVA8lT0hGSIF0Z0TedF7bOo1nRzOUdginhDw==
+
 react@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"


### PR DESCRIPTION
## Summary

Implement skeleton for a WebSocket connection between the frontend client and backend server. All API endpoints now send a websocket notification declaring that a specific resource is updated.

## Testing

Add this to `.env.local`
```
NEXT_PUBLIC_BASE_WEBSOCKETS_URL = "ws://localhost:8080"
```

Create `test.tsx` page:

```js
import React from "react";
import useWebSocket from "react-use-websocket";
import { BASE_WEBSOCKETS_URL } from "@/utils/constants";

const Test = () => {
  // In functional React component
  // This can also be an async getter function. See notes below on Async Urls.
  const socketUrl = BASE_WEBSOCKETS_URL as string;

  const {
    sendMessage,
    sendJsonMessage,
    lastMessage,
    lastJsonMessage,
    readyState,
    getWebSocket,
  } = useWebSocket(socketUrl, {
    onOpen: () => console.log("opened"),
    //Will attempt to reconnect on all close events, such as server shutting down
    shouldReconnect: (closeEvent) => true,
  });

  // const [json, setJson] = React.useState({ endpoint: "", message: "" });
  // if (lastMessage) {
  //   console.log(lastMessage.data);
  //   setJson(JSON.parse(lastMessage.data));
  // }

  return (
    <div>
      Hello there
      {lastMessage ? <span>Last message: {lastMessage.data}</span> : null}
      <button onClick={() => sendMessage("helo there lao")}>Click me</button>
    </div>
  );
};

export default Test;
```

## Notes

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->