### PR TITLE
Adjust Scheduling so that EndDate is the the same as StartDate

### DIFF
--- a/frontend/src/components/organisms/EventCardNew.tsx
+++ b/frontend/src/components/organisms/EventCardNew.tsx
@@ -20,11 +20,11 @@ const EventCardContent = ({ event }: EventCardNewProps) => {
   const date = new Date(event.startDate);
   const dateInfo = displayDateInfo(date);
   const url =
-    event.role === "SUPERVISOR"
+    event.role === "Supervisor"
       ? `/events/${event.id}/attendees`
       : `/events/${event.id}/register`;
   const buttonText =
-    event.role === "SUPERVISOR" ? "Manage Event" : "View Event Details";
+    event.role === "Supervisor" ? "Manage Event" : "View Event Details";
 
   return (
     <div>

--- a/frontend/src/components/organisms/EventForm.tsx
+++ b/frontend/src/components/organisms/EventForm.tsx
@@ -215,7 +215,8 @@ const EventForm = ({
       <Snackbar
         variety="error"
         open={errorNotificationOpen}
-        onClose={() => setErrorNotificationOpen(false)}>
+        onClose={() => setErrorNotificationOpen(false)}
+      >
         Error: {errorMessage}
       </Snackbar>
 
@@ -225,7 +226,8 @@ const EventForm = ({
             ? handleSubmit(handleCreateEvent)
             : handleSubmit(handleEditEvent)
         }
-        className="space-y-4">
+        className="space-y-4"
+      >
         <div className="font-bold text-3xl">
           {eventType == "create" ? "Create Event" : "Edit Event"}
         </div>
@@ -238,7 +240,7 @@ const EventForm = ({
             })}
           />
         </div>
-        <div className="sm:space-x-4 grid grid-cols-1 sm:grid-cols-3">
+        <div className="space-y-4 sm:space-y-0 sm:space-x-4 grid grid-cols-1 sm:grid-cols-3">
           <Controller
             name="startDate"
             control={control}
@@ -294,7 +296,8 @@ const EventForm = ({
               aria-labelledby="demo-row-radio-buttons-group-label"
               name="row-radio-buttons-group"
               defaultValue={eventDetails ? eventDetails.mode : "Virtual"}
-              sx={{ borderRadius: 2, borderColor: "primary.main" }}>
+              sx={{ borderRadius: 2, borderColor: "primary.main" }}
+            >
               <FormControlLabel
                 value="Virtual"
                 control={<Radio />}
@@ -389,7 +392,8 @@ const EventForm = ({
                 <Button
                   type="submit"
                   loading={editEventPending}
-                  disabled={editEventPending}>
+                  disabled={editEventPending}
+                >
                   Save Changes
                 </Button>
               </div>

--- a/frontend/src/components/organisms/EventForm.tsx
+++ b/frontend/src/components/organisms/EventForm.tsx
@@ -109,11 +109,6 @@ const EventForm = ({
 
   /** Handles form errors for time and date validation */
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [successMessage, setSuccessMessage] = useState<string | null>(null);
-
-  const back = () => {
-    router.push("/events/view");
-  };
 
   /** Tanstack mutation for creating a new event */
   const {
@@ -199,7 +194,6 @@ const EventForm = ({
     try {
       await handleCreateNewEvent(data);
     } catch (error) {
-      // console.error(error);
       setErrorNotificationOpen(true);
       setErrorMessage("We were unable to create this event. Please try again");
     }
@@ -210,7 +204,6 @@ const EventForm = ({
     try {
       await handleEditEventAsync(data);
     } catch (error) {
-      // console.error(error);
       setErrorNotificationOpen(true);
       setErrorMessage("We were unable to edit this event. Please try again");
     }

--- a/frontend/src/components/organisms/EventForm.tsx
+++ b/frontend/src/components/organisms/EventForm.tsx
@@ -34,21 +34,25 @@ interface EventFormProps {
 }
 
 type FormValues = {
+  id: string;
   eventName: string;
   location: string;
   volunteerSignUpCap: string;
   eventDescription: string;
   eventImage: string;
   rsvpLinkImage: string;
-  startDate: string;
-  endDate: string;
-  startTime: string;
-  endTime: string;
+  startDate: Date;
+  startTime: Date;
+  endTime: Date;
   mode: string;
 };
 
 /** An EventForm page */
-const EventForm = ({ eventId, eventType, eventDetails }: EventFormProps) => {
+const EventForm = ({
+  eventDetails,
+  eventType,
+  eventId = eventDetails?.id,
+}: EventFormProps) => {
   const { user } = useAuth();
   const queryClient = useQueryClient();
 
@@ -96,7 +100,6 @@ const EventForm = ({ eventId, eventType, eventDetails }: EventFormProps) => {
             eventImage: eventDetails.eventImage,
             rsvpLinkImage: eventDetails.rsvpLinkImage,
             startDate: eventDetails.startDate,
-            endDate: eventDetails.endDate,
             startTime: eventDetails.startTime,
             endTime: eventDetails.endTime,
           },
@@ -107,28 +110,18 @@ const EventForm = ({ eventId, eventType, eventDetails }: EventFormProps) => {
   /** Handles form errors for time and date validation */
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
-  const timeAndDateValidation = () => {
-    const { startTime, startDate, endTime, endDate } = getValues();
-    const startDateTime = convertToISO(startTime, startDate);
-    const endDateTime = convertToISO(endTime, endDate);
-    if (new Date(startDateTime) >= new Date(endDateTime)) {
-      setErrorNotificationOpen(true);
-      setErrorMessage(
-        "End Date and Time must be later than Start Date and Time"
-      );
-      return false;
-    } else {
-      setErrorMessage(null);
-    }
-    return true;
-  };
 
   const back = () => {
     router.push("/events/view");
   };
 
   /** Tanstack mutation for creating a new event */
-  const { mutateAsync, isPending, isError, isSuccess } = useMutation({
+  const {
+    mutateAsync: handleCreateNewEvent,
+    isPending,
+    isError,
+    isSuccess,
+  } = useMutation({
     mutationFn: async (data: FormValues) => {
       const mode = status === 0 ? "VIRTUAL" : "IN_PERSON";
       const {
@@ -137,21 +130,20 @@ const EventForm = ({ eventId, eventType, eventDetails }: EventFormProps) => {
         volunteerSignUpCap,
         eventDescription,
         startDate,
-        endDate,
         startTime,
         endTime,
       } = data;
-      const startDateTime = convertToISO(startTime, startDate);
-      const endDateTime = convertToISO(endTime, endDate);
       const userid = await fetchUserIdFromDatabase(user?.email as string);
+      const startDateTime = convertToISO(startTime, startDate);
+      const endDateTime = convertToISO(endTime, startDate);
       const { response } = await api.post("/events", {
         userID: `${userid}`,
         event: {
           name: `${eventName}`,
           location: status === 0 ? "VIRTUAL" : `${location}`,
           description: `${eventDescription}`,
-          startDate: new Date(startDateTime),
-          endDate: new Date(endDateTime),
+          startDate: startDateTime,
+          endDate: endDateTime,
           capacity: +volunteerSignUpCap,
           mode: `${mode}`,
         },
@@ -160,51 +152,54 @@ const EventForm = ({ eventId, eventType, eventDetails }: EventFormProps) => {
     },
     retry: false,
     onSuccess: () => {
-      setSuccessNotificationOpen(true);
-      let countdown = 3;
-      setSuccessMessage("Successfully Created Event! Redirecting...");
-      setTimeout(back, 1000);
+      localStorage.setItem("eventCreated", "true");
+      router.push("/events/view");
     },
   });
 
   /** Tanstack mutation for updating an existing event */
-  const { mutateAsync: editEvent, isPending: editEventPending } = useMutation({
-    mutationFn: async (data: FormValues) => {
-      const mode = status === 0 ? "VIRTUAL" : "IN_PERSON";
-      const { startTime, startDate, endTime, endDate } = getValues();
-      const startDateTime = convertToISO(startTime, startDate);
-      const endDateTime = convertToISO(endTime, endDate);
-      const { eventName, location, volunteerSignUpCap, eventDescription } =
-        data;
-      const { response } = await api.put(`/events/${eventId}`, {
-        name: `${eventName}`,
-        location: `${location}`,
-        description: `${eventDescription}`,
-        startDate: new Date(startDateTime),
-        endDate: new Date(endDateTime),
-        capacity: +volunteerSignUpCap,
-        mode: `${mode}`,
-      });
-      return response;
-    },
-    retry: false,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["event", eventId] });
-      setSuccessNotificationOpen(true);
-      setSuccessMessage("Successfully Edited Event! Redirecting...");
-      setTimeout(back, 1000);
-    },
-  });
+  const { mutateAsync: handleEditEventAsync, isPending: editEventPending } =
+    useMutation({
+      mutationFn: async (data: FormValues) => {
+        const mode = status === 0 ? "VIRTUAL" : "IN_PERSON";
+        const {
+          eventName,
+          location,
+          volunteerSignUpCap,
+          eventDescription,
+          startDate,
+          startTime,
+          endTime,
+        } = data;
+        const startDateTime = convertToISO(startTime, startDate);
+        const endDateTime = convertToISO(endTime, startDate);
+        const { response } = await api.put(`/events/${eventId}`, {
+          name: `${eventName}`,
+          location: `${location}`,
+          description: `${eventDescription}`,
+          startDate: startDateTime,
+          endDate: endDateTime,
+          capacity: +volunteerSignUpCap,
+          mode: `${mode}`,
+        });
+        return response;
+      },
+      retry: false,
+      onSuccess: () => {
+        queryClient.invalidateQueries({
+          queryKey: ["event", eventId],
+        });
+        localStorage.setItem("eventEdited", "true");
+        router.push("/events/view");
+      },
+    });
 
   /** Helper for handling creating events */
   const handleCreateEvent: SubmitHandler<FormValues> = async (data) => {
     try {
-      const validation = timeAndDateValidation();
-      if (validation) {
-        await mutateAsync(data);
-      }
+      await handleCreateNewEvent(data);
     } catch (error) {
-      console.error(error);
+      // console.error(error);
       setErrorNotificationOpen(true);
       setErrorMessage("We were unable to create this event. Please try again");
     }
@@ -213,12 +208,9 @@ const EventForm = ({ eventId, eventType, eventDetails }: EventFormProps) => {
   /** Helper for handling editing events */
   const handleEditEvent: SubmitHandler<FormValues> = async (data) => {
     try {
-      const validation = timeAndDateValidation();
-      if (validation) {
-        await editEvent(data);
-      }
+      await handleEditEventAsync(data);
     } catch (error) {
-      console.error(error);
+      // console.error(error);
       setErrorNotificationOpen(true);
       setErrorMessage("We were unable to edit this event. Please try again");
     }
@@ -230,22 +222,8 @@ const EventForm = ({ eventId, eventType, eventDetails }: EventFormProps) => {
       <Snackbar
         variety="error"
         open={errorNotificationOpen}
-        onClose={() => setErrorNotificationOpen(false)}
-      >
+        onClose={() => setErrorNotificationOpen(false)}>
         Error: {errorMessage}
-      </Snackbar>
-
-      {/* Success component */}
-
-      {/* TODO: It would make a lot more sense if the success notification
-      appeared on the home screen after EventForm redirects to the home page,
-      rather than waiting a timeout and then redirecting */}
-      <Snackbar
-        variety="success"
-        open={successNotificationOpen}
-        onClose={() => setSuccessNotificationOpen(false)}
-      >
-        {successMessage}
       </Snackbar>
 
       <form
@@ -254,12 +232,11 @@ const EventForm = ({ eventId, eventType, eventDetails }: EventFormProps) => {
             ? handleSubmit(handleCreateEvent)
             : handleSubmit(handleEditEvent)
         }
-        className="space-y-4"
-      >
+        className="space-y-4">
         <div className="font-bold text-3xl">
           {eventType == "create" ? "Create Event" : "Edit Event"}
         </div>
-        <div className="grid grid-cols-1 sm:grid-cols-2  col-span-2  sm:col-span-1">
+        <div className="grid grid-cols-1 col-span-2">
           <TextField
             label="Event Name"
             error={errors.eventName?.message}
@@ -268,57 +245,45 @@ const EventForm = ({ eventId, eventType, eventDetails }: EventFormProps) => {
             })}
           />
         </div>
-        <div className="sm:space-x-4 grid grid-cols-1 sm:grid-cols-2">
-          <div className="pb-4 sm:pb-0">
-            <Controller
-              name="startDate"
-              control={control}
-              rules={{ required: { value: true, message: "Required" } }}
-              defaultValue={undefined}
-              render={({ field }) => (
-                <DatePicker
-                  label="Start Date"
-                  error={errors.startDate?.message}
-                  {...field}
-                />
-              )}
-            />
-          </div>
+        <div className="sm:space-x-4 grid grid-cols-1 sm:grid-cols-3">
           <Controller
-            name="endDate"
+            name="startDate"
             control={control}
             rules={{ required: { value: true, message: "Required" } }}
-            defaultValue={undefined}
             render={({ field }) => (
               <DatePicker
-                error={errors.endDate?.message}
-                label="End Date"
+                label="Date"
+                error={errors.startDate?.message}
                 {...field}
               />
             )}
           />
-        </div>
-        <div className="sm:space-x-4 grid grid-cols-1 sm:grid-cols-2">
-          <div className="pb-4 sm:pb-0">
-            <Controller
-              name="startTime"
-              control={control}
-              rules={{ required: { value: true, message: "Required" } }}
-              defaultValue={undefined}
-              render={({ field }) => (
-                <TimePicker
-                  error={errors.startTime?.message}
-                  label="Start Time"
-                  {...field}
-                />
-              )}
-            />
-          </div>
+          <Controller
+            name="startTime"
+            control={control}
+            rules={{
+              required: { value: true, message: "Required" },
+              validate: (value) =>
+                value < watch("endTime") ||
+                "Start time must be before end time",
+            }}
+            render={({ field }) => (
+              <TimePicker
+                error={errors.startTime?.message}
+                label="Start Time"
+                {...field}
+              />
+            )}
+          />
           <Controller
             name="endTime"
             control={control}
-            rules={{ required: { value: true, message: "Required" } }}
-            defaultValue={undefined}
+            rules={{
+              required: { value: true, message: "Required" },
+              validate: (value) =>
+                value > watch("startTime") ||
+                "End time must be after start time",
+            }}
             render={({ field }) => (
               <TimePicker
                 error={errors.endTime?.message}
@@ -336,8 +301,7 @@ const EventForm = ({ eventId, eventType, eventDetails }: EventFormProps) => {
               aria-labelledby="demo-row-radio-buttons-group-label"
               name="row-radio-buttons-group"
               defaultValue={eventDetails ? eventDetails.mode : "Virtual"}
-              sx={{ borderRadius: 2, borderColor: "primary.main" }}
-            >
+              sx={{ borderRadius: 2, borderColor: "primary.main" }}>
               <FormControlLabel
                 value="Virtual"
                 control={<Radio />}
@@ -424,6 +388,7 @@ const EventForm = ({ eventId, eventType, eventDetails }: EventFormProps) => {
                   <Button>Cancel</Button>
                 </Link>
               </div>
+              {/* TODO: Add functionality */}
               <div className="sm:col-start-7 sm:col-span-3">
                 <Button>Cancel Event</Button>
               </div>
@@ -431,8 +396,7 @@ const EventForm = ({ eventId, eventType, eventDetails }: EventFormProps) => {
                 <Button
                   type="submit"
                   loading={editEventPending}
-                  disabled={editEventPending}
-                >
+                  disabled={editEventPending}>
                   Save Changes
                 </Button>
               </div>

--- a/frontend/src/components/organisms/ManageAttendees.tsx
+++ b/frontend/src/components/organisms/ManageAttendees.tsx
@@ -38,10 +38,9 @@ interface attendeeTableProps {
 }
 
 type FormValues = {
-  startDate: string;
-  endDate: string;
-  startTime: string;
-  endTime: string;
+  startDate: Date;
+  startTime: Date;
+  endTime: Date;
 };
 
 interface ManageAttendeesProps {}
@@ -87,8 +86,7 @@ const eventColumns: GridColDef[] = [
         <Select
           size="small"
           value="PENDING"
-          onChange={(event: any) => console.log(event.target.value)}
-        >
+          onChange={(event: any) => console.log(event.target.value)}>
           <MenuItem value="CHECKED IN">Checked in</MenuItem>
           <MenuItem value="CHECKED OUT">Checked out</MenuItem>
           <MenuItem value="PENDING">Pending</MenuItem>
@@ -177,7 +175,6 @@ const ModalBody = ({
       ? {
           defaultValues: {
             startDate: eventDetails.startDate,
-            endDate: eventDetails.endDate,
             startTime: eventDetails.startTime,
             endTime: eventDetails.endTime,
           },
@@ -185,35 +182,14 @@ const ModalBody = ({
       : {}
   );
 
-  /** Handles form errors for time and date validation */
-  const timeAndDateValidation = () => {
-    const { startTime, startDate, endTime, endDate } = getValues();
-    const startDateTime = convertToISO(startTime, startDate);
-    const endDateTime = convertToISO(endTime, endDate);
-    if (new Date(startDateTime) >= new Date(endDateTime)) {
-      setErrorNotificationOpen(true);
-      setErrorMessage(
-        "End Date and Time must be later than Start Date and Time"
-      );
-      return false;
-    } else {
-      setErrorMessage("");
-    }
-    return true;
-  };
-
-  const back = () => {
-    router.push("/events/view");
-  };
-
   /** Tanstack mutation for creating a new event */
   const { mutateAsync, isPending, isError, isSuccess } = useMutation({
     mutationFn: async (formData: FormValues) => {
       // const eventid = router.query.eventid as string;
       const { data } = await api.get(`/events/${eventid}`);
-      const { startDate, endDate, startTime, endTime } = formData;
+      const { startDate, startTime, endTime } = formData;
       const startDateTime = convertToISO(startTime, startDate);
-      const endDateTime = convertToISO(endTime, endDate);
+      const endDateTime = convertToISO(endTime, startDate);
       const userid = await fetchUserIdFromDatabase(user?.email as string);
       const { response } = await api.post("/events", {
         userID: `${userid}`,
@@ -222,8 +198,8 @@ const ModalBody = ({
           location: `${data["data"].location}`,
           description: `${data["data"].description}`,
           imageURL: `${data["data"].imageURL}`,
-          startDate: new Date(startDateTime),
-          endDate: new Date(endDateTime),
+          startDate: startDateTime,
+          endDate: endDateTime,
           capacity: +data["data"].capacity,
           mode: `${data["data"].mode}`,
         },
@@ -232,19 +208,18 @@ const ModalBody = ({
     },
     retry: false,
     onSuccess: () => {
-      setSuccessNotificationOpen(true);
-      setSuccessMessage("Successfully Created Event! Redirecting...");
-      setTimeout(back, 1000);
+      localStorage.setItem("eventCreated", "true");
+      queryClient.invalidateQueries({
+        queryKey: ["events"],
+      });
+      router.push("/events/view");
     },
   });
 
   /** Helper for handling duplicating events */
   const handleDuplicateEvent: SubmitHandler<FormValues> = async (data) => {
     try {
-      const validation = timeAndDateValidation();
-      if (validation) {
-        await mutateAsync(data);
-      }
+      await mutateAsync(data);
     } catch (error) {
       setErrorNotificationOpen(true);
       setErrorMessage(
@@ -256,77 +231,61 @@ const ModalBody = ({
   return (
     <div>
       <form onSubmit={handleSubmit(handleDuplicateEvent)} className="space-y-4">
-        <div className="font-bold text-center text-2xl">Duplicate Event</div>
+        <div className="font-bold text-2xl">Duplicate Event</div>
         <div className="mb-12">
-          <div className="text-center">
+          <div>
             Create a new event with the same information as this one. Everything
             except the volunteer list will be copied over.
           </div>
         </div>
         <div className="font-bold">Date and Time for New Event</div>
-        <div className="sm:space-x-0 grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <div className="pb-0 sm:pb-0">
-            <Controller
-              name="startDate"
-              control={control}
-              rules={{ required: true }}
-              defaultValue={undefined}
-              render={({ field }) => (
-                <DatePicker
-                  label={<span className="font-medium">Start Date</span>}
-                  error={errors.startDate ? "Required" : undefined}
-                  {...field}
-                />
-              )}
-            />
-          </div>
-          <div className="pb-0 sm:pb-0">
-            <Controller
-              name="startTime"
-              control={control}
-              rules={{ required: true }}
-              defaultValue={undefined}
-              render={({ field }) => (
-                <TimePicker
-                  error={errors.startTime ? "Required" : undefined}
-                  label={<span className="font-medium">Start Time</span>}
-                  {...field}
-                />
-              )}
-            />
-          </div>
-        </div>
-        <div className="sm:space-x-0 grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <div className="pb-0 sm:pb-0">
-            <Controller
-              name="endDate"
-              control={control}
-              rules={{ required: true }}
-              defaultValue={undefined}
-              render={({ field }) => (
-                <DatePicker
-                  error={errors.endDate ? "Required" : undefined}
-                  label={<span className="font-medium">End Date</span>}
-                  {...field}
-                />
-              )}
-            />
-          </div>
-          <div className="pb-0 sm:pb-0">
-            <Controller
-              name="endTime"
-              control={control}
-              rules={{ required: true }}
-              defaultValue={undefined}
-              render={({ field }) => (
-                <TimePicker
-                  error={errors.endTime ? "Required" : undefined}
-                  label={<span className="font-medium">End Time</span>}
-                  {...field}
-                />
-              )}
-            />
-          </div>
+        <div className="sm:space-x-4 grid grid-cols-1 sm:grid-cols-3">
+          <Controller
+            name="startDate"
+            control={control}
+            rules={{ required: { value: true, message: "Required" } }}
+            render={({ field }) => (
+              <DatePicker
+                label="Date"
+                error={errors.startDate?.message}
+                {...field}
+              />
+            )}
+          />
+          <Controller
+            name="startTime"
+            control={control}
+            rules={{
+              required: { value: true, message: "Required" },
+              validate: (value) =>
+                value < watch("endTime") ||
+                "Start time must be before end time",
+            }}
+            render={({ field }) => (
+              <TimePicker
+                error={errors.startTime?.message}
+                label="Start Time"
+                {...field}
+              />
+            )}
+          />
+          <Controller
+            name="endTime"
+            control={control}
+            rules={{
+              required: { value: true, message: "Required" },
+              validate: (value) =>
+                value > watch("startTime") ||
+                "End time must be after start time",
+            }}
+            render={({ field }) => (
+              <TimePicker
+                error={errors.endTime?.message}
+                label="End Time"
+                {...field}
+              />
+            )}
+          />
         </div>
         <div className="grid gird-cols-1 gap-4 sm:grid-cols-2">
           <div className="order-1 sm:order-2">
@@ -494,16 +453,14 @@ const ManageAttendees = ({}: ManageAttendeesProps) => {
       <Snackbar
         variety="error"
         open={errorNotificationOpen}
-        onClose={() => setErrorNotificationOpen(false)}
-      >
+        onClose={() => setErrorNotificationOpen(false)}>
         Error: {errorMessage}
       </Snackbar>
 
       <Snackbar
         variety="success"
         open={successNotificationOpen}
-        onClose={() => setSuccessNotificationOpen(false)}
-      >
+        onClose={() => setSuccessNotificationOpen(false)}>
         {successMessage}
       </Snackbar>
 

--- a/frontend/src/components/organisms/ManageAttendees.tsx
+++ b/frontend/src/components/organisms/ManageAttendees.tsx
@@ -86,7 +86,8 @@ const eventColumns: GridColDef[] = [
         <Select
           size="small"
           value="PENDING"
-          onChange={(event: any) => console.log(event.target.value)}>
+          onChange={(event: any) => console.log(event.target.value)}
+        >
           <MenuItem value="CHECKED IN">Checked in</MenuItem>
           <MenuItem value="CHECKED OUT">Checked out</MenuItem>
           <MenuItem value="PENDING">Pending</MenuItem>
@@ -235,7 +236,7 @@ const ModalBody = ({
           </div>
         </div>
         <div className="font-bold">Date and Time for New Event</div>
-        <div className="sm:space-x-4 grid grid-cols-1 sm:grid-cols-3">
+        <div className="space-y-4 sm:space-y-0 sm:space-x-4 grid grid-cols-1 sm:grid-cols-3">
           <Controller
             name="startDate"
             control={control}
@@ -447,7 +448,8 @@ const ManageAttendees = ({}: ManageAttendeesProps) => {
       <Snackbar
         variety="error"
         open={errorNotificationOpen}
-        onClose={() => setErrorNotificationOpen(false)}>
+        onClose={() => setErrorNotificationOpen(false)}
+      >
         Error: {errorMessage}
       </Snackbar>
 

--- a/frontend/src/components/organisms/ManageAttendees.tsx
+++ b/frontend/src/components/organisms/ManageAttendees.tsx
@@ -146,17 +146,13 @@ const ModalBody = ({
   eventDetails,
   eventid,
   setErrorMessage,
-  setSuccessMessage,
   setErrorNotificationOpen,
-  setSuccessNotificationOpen,
 }: {
   handleClose: () => void;
   eventDetails?: FormValues;
   eventid: string;
   setErrorMessage: React.Dispatch<React.SetStateAction<string>>;
-  setSuccessMessage: React.Dispatch<React.SetStateAction<string>>;
   setErrorNotificationOpen: React.Dispatch<React.SetStateAction<boolean>>;
-  setSuccessNotificationOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }) => {
   const { user } = useAuth();
   const queryClient = useQueryClient();
@@ -437,12 +433,10 @@ const ManageAttendees = ({}: ManageAttendeesProps) => {
   };
 
   /** State variables for the notification popups */
-  const [successNotificationOpen, setSuccessNotificationOpen] = useState(false);
   const [errorNotificationOpen, setErrorNotificationOpen] = useState(false);
 
   /** Handles form errors for time and date validation */
   const [errorMessage, setErrorMessage] = useState<string>("");
-  const [successMessage, setSuccessMessage] = useState<string>("");
 
   /** Loading screen */
   if (isPending) return <Loading />;
@@ -457,13 +451,6 @@ const ManageAttendees = ({}: ManageAttendeesProps) => {
         Error: {errorMessage}
       </Snackbar>
 
-      <Snackbar
-        variety="success"
-        open={successNotificationOpen}
-        onClose={() => setSuccessNotificationOpen(false)}>
-        {successMessage}
-      </Snackbar>
-
       {/* Duplicate event modal */}
       <Modal
         open={open}
@@ -473,9 +460,7 @@ const ManageAttendees = ({}: ManageAttendeesProps) => {
             eventid={eventid}
             handleClose={handleClose}
             setErrorMessage={setErrorMessage}
-            setSuccessMessage={setSuccessMessage}
             setErrorNotificationOpen={setErrorNotificationOpen}
-            setSuccessNotificationOpen={setSuccessNotificationOpen}
           />
         }
       />

--- a/frontend/src/components/organisms/ViewEventDetails.tsx
+++ b/frontend/src/components/organisms/ViewEventDetails.tsx
@@ -111,7 +111,12 @@ const ViewEventDetails = () => {
           <Markdown>{description}</Markdown>
         </div>
       }
-      img={<img className="w-full rounded-2xl" src="/lfbi_splash.png" />}
+      img={
+        <img
+          className="w-full rounded-2xl"
+          src={image_src || "/lfbi_splash.png"}
+        />
+      }
       card={
         userHasCanceledAttendance ? (
           <EventCardCancelConfirmation />

--- a/frontend/src/components/organisms/ViewEvents.tsx
+++ b/frontend/src/components/organisms/ViewEvents.tsx
@@ -17,6 +17,8 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import Loading from "@/components/molecules/Loading";
 import Error from "./Error";
 import { formatDateString } from "@/utils/helpers";
+import Snackbar from "../atoms/Snackbar";
+
 
 /** Displays upcoming events for the user */
 const UpcomingEvents = () => {
@@ -390,12 +392,6 @@ const PastEvents = () => {
     },
   ];
 
-  /** Loading screen */
-  // if (isLoading) return <Loading />;
-
-  /** Error screen */
-  // if (isError) return <Error />;
-
   return (
     <>
       <Table
@@ -431,8 +427,38 @@ const ViewEvents = () => {
       },
     ];
 
+    const [isEventCreated, setIsEventCreated] = useState(false);
+    const [isEventEdited, setIsEventEdited] = useState(false);
+
+    useEffect(() => {
+      const isEventCreated = localStorage.getItem("eventCreated");
+      if (isEventCreated) {
+        setIsEventCreated(true);
+        localStorage.removeItem("eventCreated");
+      }
+      if (localStorage.getItem("eventEdited")) {
+        setIsEventEdited(true);
+        localStorage.removeItem("eventEdited");
+      }
+    }, []);
+
     return (
       <>
+        {/* Event creation success notification */}
+        <Snackbar
+          variety="success"
+          open={isEventCreated}
+          onClose={() => setIsEventCreated(false)}>
+          Your event was successfully created!
+        </Snackbar>
+
+        {/* Event editing success notification */}
+        <Snackbar
+          variety="success"
+          open={isEventEdited}
+          onClose={() => setIsEventEdited(false)}>
+          Your event has been successfully updated!
+        </Snackbar>
         <TabContainer
           tabs={tabs}
           left={<div className="text-3xl font-semibold">My Events</div>}

--- a/frontend/src/pages/events/[eventid]/edit.tsx
+++ b/frontend/src/pages/events/[eventid]/edit.tsx
@@ -7,16 +7,17 @@ import { api } from "@/utils/api";
 import { useQuery } from "@tanstack/react-query";
 
 type eventData = {
+  id: string;
   eventName: string;
   location: string;
   volunteerSignUpCap: string;
   eventDescription: string;
   eventImage: string;
   rsvpLinkImage: string;
-  startDate: string;
-  endDate: string;
-  startTime: string;
-  endTime: string;
+  startDate: Date;
+  endDate: Date;
+  startTime: Date;
+  endTime: Date;
   mode: string;
 };
 
@@ -34,6 +35,7 @@ const EditEvent = () => {
     },
   });
   let event: eventData = {
+    id: data?.id,
     eventName: data?.name,
     location: data?.location,
     volunteerSignUpCap: data?.capacity,
@@ -52,7 +54,7 @@ const EditEvent = () => {
 
   return (
     <CenteredTemplate>
-      <EventForm eventId={eventid} eventType="edit" eventDetails={event} />
+      <EventForm eventType="edit" eventDetails={event} />
     </CenteredTemplate>
   );
 };

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -1,6 +1,6 @@
 import dayjs from "dayjs";
 import { api } from "./api";
-import { isToday, isTomorrow, isPast } from "date-fns";
+import { isToday, isTomorrow, isPast, parseISO, format } from "date-fns";
 
 /**
  * This functions performs a search in the DB based on the email of the user that
@@ -69,35 +69,11 @@ export const formatDateString = (dateString: string) => {
  * @param inputDate is the inputDate
  * @returns the ISO string
  */
-export const convertToISO = (inputTime: string, inputDate: string) => {
-  var timeIndex = 0;
-  var counter = 0;
-  const time = String(inputTime);
-  const date = String(inputDate);
-  for (let i = 0; i < time.length; i++) {
-    if (time[i] === " ") {
-      counter += 1;
-      if (counter === 4) {
-        timeIndex = i;
-        counter = 0;
-        break;
-      }
-    }
-  }
-  var dateIndex = 0;
-  for (let i = 0; i < date.length; i++) {
-    if (date[i] === " ") {
-      counter += 1;
-      if (counter === 4) {
-        dateIndex = i;
-        counter = 0;
-        break;
-      }
-    }
-  }
-  const rawDateTime = date.substring(0, dateIndex) + time.substring(timeIndex);
-  const res = dayjs(rawDateTime).toJSON();
-  return res;
+export const convertToISO = (inputTime: Date, inputDate: Date) => {
+  const date = format(new Date(inputDate), "yyyy-MM-dd");
+  const time = format(new Date(inputTime), "HH:mm:ss");
+
+  return dayjs(`${date} ${time}`).toJSON(); 
 };
 
 /**


### PR DESCRIPTION
## Summary

As we discussed, this removes endDate altogether, and simplifies things A LOT.

## Testing
Note: Screenshots for reference: you will notice the new layout and that the errors show up under the inputs, not as notifications
![Screenshot 2024-04-06 at 19 32 34](https://github.com/cornellh4i/lagos-volunteers/assets/59776300/fa669b40-005d-44a6-aeb7-ca93cc43ce50)

Additionally, when you create a new event, you are immediately redirected back to the home page, but you see this: I think it's better implementation
![Screenshot 2024-04-06 at 19 33 30](https://github.com/cornellh4i/lagos-volunteers/assets/59776300/da5781b0-d240-46c0-beb3-f7066fcc8e0f)

Finally addressed some minor bugs:
- The duplicate event is also adjusted to not include endDate
- The view events is updated so that events you create show the "Manage event" button
- also fixed minor bug where all the events where using the same photo
## Notes
- There is still the bug where the startTime can be in the past. 
<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->