### PR TITLE
Address some bugs in creating events

### DIFF
--- a/frontend/src/components/atoms/LocationPicker.tsx
+++ b/frontend/src/components/atoms/LocationPicker.tsx
@@ -190,12 +190,14 @@ const LocationPicker = ({
                 </Grid>
                 <Grid
                   item
-                  sx={{ width: "calc(100% - 44px)", wordWrap: "break-word" }}>
+                  sx={{ width: "calc(100% - 44px)", wordWrap: "break-word" }}
+                >
                   {parts.map((part, index) => (
                     <Box
                       key={index}
                       component="span"
-                      sx={{ fontWeight: part.highlight ? "bold" : "regular" }}>
+                      sx={{ fontWeight: part.highlight ? "bold" : "regular" }}
+                    >
                       {part.text}
                     </Box>
                   ))}

--- a/frontend/src/components/atoms/LocationPicker.tsx
+++ b/frontend/src/components/atoms/LocationPicker.tsx
@@ -55,10 +55,11 @@ interface LocationPickerProps {
 const LocationPicker = ({
   label,
   form,
+  defaultValue,
   error = "",
   ...props
 }: LocationPickerProps) => {
-  const [value, setValue] = React.useState<PlaceType | null>(null);
+  const [value, setValue] = React.useState<PlaceType | null>(defaultValue);
   const [inputValue, setInputValue] = React.useState("");
   const [options, setOptions] = React.useState<readonly PlaceType[]>([]);
   const loaded = React.useRef(false);
@@ -135,6 +136,7 @@ const LocationPicker = ({
       <div className="mb-1">{label}</div>
       <Autocomplete
         {...props}
+        freeSolo
         id="google-map-demo"
         getOptionLabel={(option) =>
           typeof option === "string" ? option : option.description
@@ -146,9 +148,18 @@ const LocationPicker = ({
         filterSelectedOptions
         value={value}
         noOptionsText="No locations"
-        onChange={(event: any, newValue: PlaceType | null) => {
-          setOptions(newValue ? [newValue, ...options] : options);
-          setValue(newValue);
+        onChange={(event: any, newValue: PlaceType | string | null) => {
+          if (typeof newValue === "string") {
+            newValue = {
+              description: newValue,
+              structured_formatting: {
+                main_text: newValue,
+                secondary_text: "",
+              },
+            };
+            setOptions(newValue ? [newValue, ...options] : options);
+            setValue(newValue);
+          }
         }}
         onInputChange={(event, newInputValue) => {
           setInputValue(newInputValue);
@@ -158,6 +169,9 @@ const LocationPicker = ({
         }}
         renderInput={(params) => <TextField {...params} />}
         renderOption={(props, option) => {
+          if (typeof option === "string") {
+            return <div>{option}</div>;
+          }
           const matches =
             option.structured_formatting.main_text_matched_substrings || [];
 
@@ -168,7 +182,6 @@ const LocationPicker = ({
               match.offset + match.length,
             ])
           );
-
           return (
             <li {...props}>
               <Grid container alignItems="center">
@@ -177,14 +190,12 @@ const LocationPicker = ({
                 </Grid>
                 <Grid
                   item
-                  sx={{ width: "calc(100% - 44px)", wordWrap: "break-word" }}
-                >
+                  sx={{ width: "calc(100% - 44px)", wordWrap: "break-word" }}>
                   {parts.map((part, index) => (
                     <Box
                       key={index}
                       component="span"
-                      sx={{ fontWeight: part.highlight ? "bold" : "regular" }}
-                    >
+                      sx={{ fontWeight: part.highlight ? "bold" : "regular" }}>
                       {part.text}
                     </Box>
                   ))}

--- a/frontend/src/components/organisms/EventForm.tsx
+++ b/frontend/src/components/organisms/EventForm.tsx
@@ -218,7 +218,8 @@ const EventForm = ({
       <Snackbar
         variety="error"
         open={errorNotificationOpen}
-        onClose={() => setErrorNotificationOpen(false)}>
+        onClose={() => setErrorNotificationOpen(false)}
+      >
         Error: {errorMessage}
       </Snackbar>
 
@@ -228,7 +229,8 @@ const EventForm = ({
             ? handleSubmit(handleCreateEvent)
             : handleSubmit(handleEditEvent)
         }
-        className="space-y-4">
+        className="space-y-4"
+      >
         <div className="font-bold text-3xl">
           {eventType == "create" ? "Create Event" : "Edit Event"}
         </div>
@@ -299,7 +301,8 @@ const EventForm = ({
               defaultValue={
                 eventDetails?.mode === "VIRTUAL" ? "Virtual" : "In_Person"
               }
-              sx={{ borderRadius: 2, borderColor: "primary.main" }}>
+              sx={{ borderRadius: 2, borderColor: "primary.main" }}
+            >
               <FormControlLabel
                 value="Virtual"
                 control={<Radio />}
@@ -409,7 +412,8 @@ const EventForm = ({
                 <Button
                   type="submit"
                   loading={editEventPending}
-                  disabled={editEventPending}>
+                  disabled={editEventPending}
+                >
                   Save Changes
                 </Button>
               </div>

--- a/frontend/src/components/templates/EventTemplate.tsx
+++ b/frontend/src/components/templates/EventTemplate.tsx
@@ -15,7 +15,7 @@ const EventTemplate = ({ header, body, img, card }: EventTemplateProps) => {
       {/* DESKTOP VIEW */}
       <div className="hidden sm:flex">
         {/* Left column */}
-        <div className="flex-1 mr-6">
+        <div className="flex-1 mr-6 overflow-auto">
           {header}
           {body}
         </div>


### PR DESCRIPTION
## Summary

Bug fixes include:
- can now enter an address if a Google maps location autocomplete does not return anything
- can now enter and edit descriptions - before it was hard coded as hello world even after creating
- correct radio is checked (virtual or in-person) and in-person location shows when editing the event
- fixed overflow issues- before when text was long it would push the right component too far and messes up the styling
- 

## Testing

try to create/ edit an event!

## Notes

Any other bugs I missed? I think it's best to address them all now 