### PR TITLE
Created Modal in ProfileForm.tsx, added profile deletion from firebas…

### DIFF
--- a/backend/src/users/views.ts
+++ b/backend/src/users/views.ts
@@ -78,8 +78,8 @@ userRouter.post(
 
 userRouter.delete("/:userid", useAuth, async (req: Request, res: Response) => {
   // #swagger.tags = ['Users']
+  await admin.auth().deleteUser(req.params.userid);
   attempt(res, 200, () => userController.deleteUser(req.params.userid));
-  await admin.auth().deleteUser(req.params.userid); //put await and attempt in same promise (try-catch like above route)
   socketNotify("/users");
 });
 

--- a/backend/src/users/views.ts
+++ b/backend/src/users/views.ts
@@ -11,6 +11,7 @@ import {
 const userRouter = Router();
 import * as firebase from "firebase-admin";
 import { attempt, socketNotify } from "../utils/helpers";
+import admin from "firebase-admin";
 
 let useAuth: RequestHandler;
 
@@ -78,6 +79,7 @@ userRouter.post(
 userRouter.delete("/:userid", useAuth, async (req: Request, res: Response) => {
   // #swagger.tags = ['Users']
   attempt(res, 200, () => userController.deleteUser(req.params.userid));
+  await admin.auth().deleteUser(req.params.userid); //put await and attempt in same promise (try-catch like above route)
   socketNotify("/users");
 });
 

--- a/frontend/src/components/atoms/Button.tsx
+++ b/frontend/src/components/atoms/Button.tsx
@@ -5,7 +5,7 @@ import CircularProgress from "@mui/material/CircularProgress";
 interface ButtonProps {
   children: ReactNode;
   icon?: ReactNode;
-  variety?: "primary" | "secondary" | "tertiary" | "error";
+  variety?: "primary" | "secondary" | "tertiary" | "error" | "bigred";
   size?: "small" | "medium";
   loading?: boolean;
   [key: string]: any;
@@ -53,6 +53,9 @@ const Button = ({
       variant = "outlined";
       color = "error";
       break;
+    case "bigred":
+      variant = "contained";
+      color = "error";
   }
 
   return (

--- a/frontend/src/components/organisms/ProfileForm.tsx
+++ b/frontend/src/components/organisms/ProfileForm.tsx
@@ -65,16 +65,14 @@ const ModalBody = ({ userDetails, handleClose }: ModalBodyProps) => {
   } = useForm<DeleteAccountFormValues>();
 
   //changeUserStatus handles deleting user from prisma and firebase
-  const { mutateAsync: changeUserStatus, error: changeUserStatusError } =
+  const { mutateAsync: deleteUserProfile, error: deleteUserProfileError } =
     useMutation({
       mutationFn: async () => {
         const { data } = await api.delete(`/users/${userDetails.id}`);
         return data;
       },
       retry: false,
-      onSuccess: () => {
-        console.log("DELETED");
-      },
+      onSuccess: () => {},
     });
 
   //Variables for signing out user
@@ -97,8 +95,12 @@ const ModalBody = ({ userDetails, handleClose }: ModalBodyProps) => {
    * and redirect them to login page
    */
   const handleDeleteAccount = async () => {
-    await changeUserStatus();
-    await handleSignOut();
+    try {
+      await deleteUserProfile();
+      await handleSignOut();
+    } catch (error) {
+      console.log(error);
+    }
   };
 
   return (
@@ -261,17 +263,6 @@ const ProfileForm = ({ userDetails }: ProfileFormProps) => {
       setErrorMessage(error.message);
     }
   };
-
-  // const { mutateAsync: changeUserStatus } = useMutation({
-  //   mutationFn: async () => {
-  //     const { data } = await api.delete(`/users/${userid}`);
-  //     return data;
-  //   },
-  //   retry: false,
-  //   onSuccess: () => {
-  //     console.log("DELETED");
-  //   }
-  // });
 
   return (
     <>

--- a/frontend/src/components/organisms/ProfileForm.tsx
+++ b/frontend/src/components/organisms/ProfileForm.tsx
@@ -7,12 +7,7 @@ import Snackbar from "../atoms/Snackbar";
 import { useRouter } from "next/router";
 import { api } from "@/utils/api";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { updatePassword } from "firebase/auth";
-import { User } from "firebase/auth";
 import Modal from "@/components/molecules/Modal";
-import { Box, IconButton } from "@mui/material";
-import { Grid } from "@mui/material";
-
 import { useAuth } from "@/utils/AuthContext"; // - ndavid
 import { Controller } from "react-hook-form";
 

--- a/frontend/src/components/organisms/ProfileForm.tsx
+++ b/frontend/src/components/organisms/ProfileForm.tsx
@@ -137,7 +137,7 @@ const ModalBody = ({
         />
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 mt-10">
           <div className="order-1 sm:order-2">
-            <Button loading={isPending} variety="bigred" type="submit">
+            <Button loading={isPending} variety="mainError" type="submit">
               Delete
             </Button>
           </div>
@@ -329,6 +329,11 @@ const ProfileForm = ({ userDetails }: ProfileFormProps) => {
             <Button type="submit">Save changes</Button>
           </div>
           <div className="order-2 sm:order-2">
+            <Button variety="error" type="button" onClick={handleOpen}>
+              Delete account
+            </Button>
+          </div>
+          <div className="order-2 sm:order-1">
             <Button
               type="button"
               variety="secondary"
@@ -338,11 +343,6 @@ const ProfileForm = ({ userDetails }: ProfileFormProps) => {
               disabled={!isDirty}
             >
               Reset changes
-            </Button>
-          </div>
-          <div className="order-2 sm:order-1">
-            <Button variety="error" type="button" onClick={handleOpen}>
-              Delete account
             </Button>
           </div>
         </div>

--- a/frontend/src/components/organisms/ProfileForm.tsx
+++ b/frontend/src/components/organisms/ProfileForm.tsx
@@ -55,7 +55,7 @@ interface ModalBodyProps {
   setErrorNotificationOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-/** Confirmation Modal To Delete An Account */
+/** Confirmation modal to delete an account */
 const ModalBody = ({
   userDetails,
   handleClose,
@@ -82,12 +82,12 @@ const ModalBody = ({
     onSuccess: () => {},
   });
 
-  //Variables for signing out user
+  // Variables for signing out user
   const { error, signOutUser } = useAuth();
   const queryClient = useQueryClient();
   const router = useRouter();
 
-  //Signs out user and redirects them to login page
+  // Signs out user and redirects them to login page
   const handleSignOut = async () => {
     try {
       await signOutUser();
@@ -98,7 +98,8 @@ const ModalBody = ({
     }
   };
 
-  /**  When delete form is submitted, we will delete user, end their session,
+  /**
+   * When delete form is submitted, we will delete user, end their session,
    * and redirect them to login page
    */
   const handleDeleteAccount = async () => {

--- a/frontend/src/pages/profile.tsx
+++ b/frontend/src/pages/profile.tsx
@@ -57,7 +57,7 @@ const Profile = () => {
         and should absolutely be refactored into something sane ASAP */}
         <h3 className="mt-0 mb-2 font-normal">
           You are {data?.role === "ADMIN" ? "an " : "a "}
-          <span className="font-bold">{formatRoleOrStatus(data.role)}</span>
+          <span className="font-bold">{formatRoleOrStatus(data?.role)}</span>
         </h3>
         {data?.role === "ADMIN" && (
           <div>


### PR DESCRIPTION
# H1 Account-Deletion-FullStack

## Summary
1. Created changeUserStatus function in ProfileForm.tsx which makes a call to /users/:userid endpoint to delete user from prisma and firebase databases (added ability to delete from firebase database in views.ts)
2. Created a Modal for deleting account in ProfileForm.tsx; when account is deleted the user's session ends, they are rerouted to login page and their account is deleted

<!-- Summarize your changes here. -->

## Testing
1. Created dummy accounts to test the endpoint on postman and then on our local code

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

## Notes
1. Akin noted the importance of having the prisma and firebase deletion in the same promise

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->