### PR TITLE
Automatic data refresh

### DIFF
--- a/backend/api-spec.json
+++ b/backend/api-spec.json
@@ -124,6 +124,11 @@
             "type": "string"
           },
           {
+            "name": "attendeeStatus",
+            "in": "query",
+            "type": "string"
+          },
+          {
             "name": "sort",
             "in": "query",
             "type": "string"
@@ -785,8 +790,8 @@
         }
       }
     },
-    "/events/{eventid}/users/{userid}": {
-      "put": {
+    "/events/{eventid}/attendees/{userid}/attendee-status": {
+      "patch": {
         "tags": [
           "Events"
         ],
@@ -810,7 +815,7 @@
             "schema": {
               "type": "object",
               "properties": {
-                "status": {
+                "attendeeStatus": {
                   "example": "any"
                 }
               }

--- a/backend/src/events/views.ts
+++ b/backend/src/events/views.ts
@@ -121,7 +121,7 @@ eventRouter.patch(
         req.params.userid,
         attendeeStatus
       )
-    ); 
+    );
     socketNotify(`/events/${req.params.eventid}`);
   }
 );

--- a/backend/src/events/views.ts
+++ b/backend/src/events/views.ts
@@ -121,7 +121,8 @@ eventRouter.patch(
         req.params.userid,
         attendeeStatus
       )
-    ); socketNotify(`/events/${req.params.eventid}`)
+    ); 
+    socketNotify(`/events/${req.params.eventid}`);
   }
 );
 

--- a/backend/src/events/views.ts
+++ b/backend/src/events/views.ts
@@ -121,7 +121,7 @@ eventRouter.patch(
         req.params.userid,
         attendeeStatus
       )
-    );
+    ); socketNotify(`/events/${req.params.eventid}`)
   }
 );
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -10,7 +10,7 @@ wss.on("connection", (ws) => {
   // What happens when the server receives data
   ws.on("message", (data) => {
     console.log("received: %s", data);
-    ws.send("received: " + data);
+    ws.send("" + data);
   });
 
   // Default message to send when connected

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -10,7 +10,7 @@ wss.on("connection", (ws) => {
   // What happens when the server receives data
   ws.on("message", (data) => {
     console.log("received: %s", data);
-    ws.send("server received your message!");
+    ws.send("received: " + data);
   });
 
   // Default message to send when connected

--- a/frontend/src/components/organisms/ManageAttendees.tsx
+++ b/frontend/src/components/organisms/ManageAttendees.tsx
@@ -107,23 +107,16 @@ const AttendeesTable = ({
     retry: false,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['event', eventId] });
-      // Send a message through WebSocket upon successful mutation
-      sendMessage(`Status change successful for event ${eventId}`);
     },
   });
 
   //Handle new websocket messages
-  const previousLastMessage: React.MutableRefObject<any> = useRef();
-  
-  if (lastMessage && lastMessage !== previousLastMessage.current) {
-    console.log("Got a new message");
-    console.log(lastMessage.data);
-    if (lastMessage.data == `received: Status change successful for event ${eventId}`) {
-      console.log("Change made to this event received")
-      queryClient.invalidateQueries({ queryKey: ['event', eventId] });
-    }
-    previousLastMessage.current = lastMessage;
+
+  if (lastMessage && lastMessage.data == `{"resource":"/events/${eventId}","message":"The resource has been updated!"}`) {
+    console.log("Change made to this event received")
+    queryClient.invalidateQueries({ queryKey: ['event', eventId] });
   };
+  
 
   const handleStatusChange = async (userId: string, newValue: string) => {
     if (!eventId) {

--- a/frontend/src/components/organisms/ManageAttendees.tsx
+++ b/frontend/src/components/organisms/ManageAttendees.tsx
@@ -88,7 +88,6 @@ const AttendeesTable = ({
     lastMessage,
     readyState,
   } = useWebSocket(socketUrl, {
-    onOpen: () => console.log('WebSocket connection opened'),
     shouldReconnect: () => true,
   });
 
@@ -113,7 +112,6 @@ const AttendeesTable = ({
   //Handle new websocket messages
 
   if (lastMessage && lastMessage.data == `{"resource":"/events/${eventId}","message":"The resource has been updated!"}`) {
-    console.log("Change made to this event received")
     queryClient.invalidateQueries({ queryKey: ['event', eventId] });
   };
   
@@ -463,7 +461,6 @@ const Pending = () => {
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     // Prevent page refresh
     event.preventDefault();
-    //sendMessage("helo there lao");
     // Set search query
     setSearchQuery(value);
   };

--- a/frontend/src/components/organisms/ManageAttendees.tsx
+++ b/frontend/src/components/organisms/ManageAttendees.tsx
@@ -1,4 +1,10 @@
-import React, { ChangeEvent, FormEvent, useEffect, useRef, useState } from "react";
+import React, {
+  ChangeEvent,
+  FormEvent,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import TabContainer from "@/components/molecules/TabContainer";
 import { GridColDef, GridPaginationModel } from "@mui/x-data-grid";
 import Table from "@/components/molecules/Table";
@@ -41,7 +47,6 @@ import { BASE_URL_CLIENT } from "@/utils/constants";
 import useWebSocket from "react-use-websocket";
 import { BASE_WEBSOCKETS_URL } from "@/utils/constants";
 
-
 //Initial push
 
 type attendeeData = {
@@ -83,11 +88,7 @@ const AttendeesTable = ({
   const socketUrl = BASE_WEBSOCKETS_URL as string;
 
   // Use the useWebSocket hook
-  const {
-    sendMessage,
-    lastMessage,
-    readyState,
-  } = useWebSocket(socketUrl, {
+  const { sendMessage, lastMessage, readyState } = useWebSocket(socketUrl, {
     shouldReconnect: () => true,
   });
 
@@ -105,16 +106,19 @@ const AttendeesTable = ({
     },
     retry: false,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['event', eventId] });
+      queryClient.invalidateQueries({ queryKey: ["event", eventId] });
     },
   });
 
   //Handle new websocket messages
 
-  if (lastMessage && lastMessage.data == `{"resource":"/events/${eventId}","message":"The resource has been updated!"}`) {
-    queryClient.invalidateQueries({ queryKey: ['event', eventId] });
-  };
-  
+  if (
+    lastMessage &&
+    lastMessage.data ==
+      `{"resource":"/events/${eventId}","message":"The resource has been updated!"}`
+  ) {
+    queryClient.invalidateQueries({ queryKey: ["event", eventId] });
+  }
 
   const handleStatusChange = async (userId: string, newValue: string) => {
     if (!eventId) {
@@ -183,7 +187,6 @@ const AttendeesTable = ({
       ),
     },
   ];
-
 
   return (
     <>


### PR DESCRIPTION
## Summary

When one instance of the frontend makes a change to the attendee status of an event, it will automatically update for other instances of the frontend.

## Testing

Manually tested using two private browsers on the same computer

## Notes

I noticed that the pattern in backend/src/events/views is that each socketnotify resource is simply the event that is being updated, so when I added a socketnotify to the route relevant to this ticket, I followed the same convention. I'm wondering if we can/should make the socketnotify resource more specific for each route, so that data refreshes are only happening exactly when they need to.