### PR TITLE
Upload images fullstack

### DIFF
--- a/frontend/src/components/atoms/Dropzone.tsx
+++ b/frontend/src/components/atoms/Dropzone.tsx
@@ -17,7 +17,6 @@ const Dropzone = ({
   setSelectedFile,
   label,
 }: DropzoneProps) => {
-  // const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const allowedFileTypes = ["image/jpg", "image/jpeg", "image/png"];
   const maxFileSize = 50 * 1024 * 1024; // 50 MB
 

--- a/frontend/src/components/atoms/Dropzone.tsx
+++ b/frontend/src/components/atoms/Dropzone.tsx
@@ -2,6 +2,8 @@ import React, { useState } from "react";
 
 interface DropzoneProps {
   setError: React.Dispatch<React.SetStateAction<string>>;
+  selectedFile: File | null;
+  setSelectedFile: React.Dispatch<React.SetStateAction<File | null>>;
   label?: string;
 }
 
@@ -9,8 +11,13 @@ interface DropzoneProps {
  * Dropzone component that allows uploading files. Requires a setState to be
  * passed in to handle file upload errors.
  */
-const Dropzone = ({ setError, label }: DropzoneProps) => {
-  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+const Dropzone = ({
+  setError,
+  selectedFile,
+  setSelectedFile,
+  label,
+}: DropzoneProps) => {
+  // const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const allowedFileTypes = ["image/jpg", "image/jpeg", "image/png"];
   const maxFileSize = 50 * 1024 * 1024; // 50 MB
 

--- a/frontend/src/components/atoms/Dropzone.tsx
+++ b/frontend/src/components/atoms/Dropzone.tsx
@@ -53,18 +53,13 @@ const Dropzone = ({
           <div className="flex flex-col items-center justify-center pt-5 pb-6">
             {selectedFile === null ? (
               <>
-                <div className="flex items-center">
-                  <img src={props.defaultValue} className="max-h-20 mr-4" />
-                  <div>
-                    <p className="mb-2 text-sm text-gray-500 dark:text-gray-400">
-                      <span className="font-semibold">Click to upload</span> or
-                      drag and drop
-                    </p>
-                    <p className="text-xs text-gray-500 dark:text-gray-400">
-                      PNG or JPG (MAX. 50 MB)
-                    </p>
-                  </div>
-                </div>
+                <p className="mb-2 text-sm text-gray-500 dark:text-gray-400">
+                  <span className="font-semibold">Click to upload</span> or drag
+                  and drop
+                </p>
+                <p className="mb-2 text-sm text-gray-500 dark:text-gray-400">
+                  PNG or JPG (MAX. 50 MB)
+                </p>
               </>
             ) : (
               <>

--- a/frontend/src/components/atoms/Dropzone.tsx
+++ b/frontend/src/components/atoms/Dropzone.tsx
@@ -5,6 +5,7 @@ interface DropzoneProps {
   selectedFile: File | null;
   setSelectedFile: React.Dispatch<React.SetStateAction<File | null>>;
   label?: string;
+  [key: string]: any;
 }
 
 /**
@@ -16,6 +17,7 @@ const Dropzone = ({
   selectedFile,
   setSelectedFile,
   label,
+  ...props
 }: DropzoneProps) => {
   const allowedFileTypes = ["image/jpg", "image/jpeg", "image/png"];
   const maxFileSize = 50 * 1024 * 1024; // 50 MB
@@ -51,13 +53,18 @@ const Dropzone = ({
           <div className="flex flex-col items-center justify-center pt-5 pb-6">
             {selectedFile === null ? (
               <>
-                <p className="mb-2 text-sm text-gray-500 dark:text-gray-400">
-                  <span className="font-semibold">Click to upload</span> or drag
-                  and drop
-                </p>
-                <p className="text-xs text-gray-500 dark:text-gray-400">
-                  PNG or JPG (MAX. 50 MB)
-                </p>
+                <div className="flex items-center">
+                  <img src={props.defaultValue} className="max-h-20 mr-4" />
+                  <div>
+                    <p className="mb-2 text-sm text-gray-500 dark:text-gray-400">
+                      <span className="font-semibold">Click to upload</span> or
+                      drag and drop
+                    </p>
+                    <p className="text-xs text-gray-500 dark:text-gray-400">
+                      PNG or JPG (MAX. 50 MB)
+                    </p>
+                  </div>
+                </div>
               </>
             ) : (
               <>

--- a/frontend/src/components/atoms/Dropzone.tsx
+++ b/frontend/src/components/atoms/Dropzone.tsx
@@ -57,7 +57,7 @@ const Dropzone = ({
                   <span className="font-semibold">Click to upload</span> or drag
                   and drop
                 </p>
-                <p className="mb-2 text-sm text-gray-500 dark:text-gray-400">
+                <p className="text-xs text-gray-500 dark:text-gray-400">
                   PNG or JPG (MAX. 50 MB)
                 </p>
               </>

--- a/frontend/src/components/organisms/EventForm.tsx
+++ b/frontend/src/components/organisms/EventForm.tsx
@@ -394,20 +394,12 @@ const EventForm = ({
             })}
           />
         </div>
-        <Controller
-          name="imageURL"
-          control={control}
-          rules={{ required: { value: true, message: "Required" } }}
-          render={({ field }) => (
-            <Dropzone
-              setError={setDropzoneError}
-              label="Event Image"
-              selectedFile={selectedFile}
-              setSelectedFile={setSelectedFile}
-              {...field}
-              defaultValue={eventDetails?.imageURL}
-            />
-          )}
+        <Dropzone
+          setError={setDropzoneError}
+          label="Event Image"
+          selectedFile={selectedFile}
+          setSelectedFile={setSelectedFile}
+          defaultValue={eventDetails?.imageURL}
         />
 
         {/* <TextCopy

--- a/frontend/src/components/organisms/EventForm.tsx
+++ b/frontend/src/components/organisms/EventForm.tsx
@@ -240,7 +240,8 @@ const EventForm = ({
       <Snackbar
         variety="error"
         open={errorNotificationOpen}
-        onClose={() => setErrorNotificationOpen(false)}>
+        onClose={() => setErrorNotificationOpen(false)}
+      >
         Error: {errorMessage}
       </Snackbar>
 
@@ -250,7 +251,8 @@ const EventForm = ({
             ? handleSubmit(handleCreateEvent)
             : handleSubmit(handleEditEvent)
         }
-        className="space-y-4">
+        className="space-y-4"
+      >
         <div className="font-bold text-3xl">
           {eventType == "create" ? "Create Event" : "Edit Event"}
         </div>
@@ -321,7 +323,8 @@ const EventForm = ({
               defaultValue={
                 eventDetails?.mode === "VIRTUAL" ? "Virtual" : "In_Person"
               }
-              sx={{ borderRadius: 2, borderColor: "primary.main" }}>
+              sx={{ borderRadius: 2, borderColor: "primary.main" }}
+            >
               <FormControlLabel
                 value="Virtual"
                 control={<Radio />}
@@ -444,7 +447,8 @@ const EventForm = ({
                 <Button
                   type="submit"
                   loading={editEventPending}
-                  disabled={editEventPending}>
+                  disabled={editEventPending}
+                >
                   Save changes
                 </Button>
               </div>

--- a/frontend/src/components/organisms/EventForm.tsx
+++ b/frontend/src/components/organisms/EventForm.tsx
@@ -20,8 +20,7 @@ import Snackbar from "../atoms/Snackbar";
 import {
   convertToISO,
   fetchUserIdFromDatabase,
-  uploadImage,
-  fetchImageURLFromDB,
+  uploadImageToFirebase,
 } from "@/utils/helpers";
 import { api } from "@/utils/api";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
@@ -44,6 +43,7 @@ type FormValues = {
   location: string;
   volunteerSignUpCap: string;
   eventDescription: string;
+  imageURL: string;
   rsvpLinkImage: string;
   startDate: Date;
   startTime: Date;
@@ -107,6 +107,7 @@ const EventForm = ({
             location: eventDetails.location,
             volunteerSignUpCap: eventDetails.volunteerSignUpCap,
             eventDescription: eventDetails.eventDescription,
+            imageURL: eventDetails.imageURL,
             rsvpLinkImage: eventDetails.rsvpLinkImage,
             startDate: eventDetails.startDate,
             startTime: eventDetails.startTime,
@@ -133,6 +134,7 @@ const EventForm = ({
         location,
         volunteerSignUpCap,
         eventDescription,
+        imageURL,
         startDate,
         startTime,
         endTime,
@@ -140,9 +142,9 @@ const EventForm = ({
       const userid = await fetchUserIdFromDatabase(user?.email as string);
       const startDateTime = convertToISO(startTime, startDate);
       const endDateTime = convertToISO(endTime, startDate);
-      let imageURL = null;
+      let newImageURL = null;
       if (selectedFile) {
-        imageURL = await uploadImage(userid, selectedFile);
+        newImageURL = await uploadImageToFirebase(userid, selectedFile);
       }
 
       const { response } = await api.post("/events", {
@@ -151,7 +153,7 @@ const EventForm = ({
           name: `${eventName}`,
           location: status === 0 ? "VIRTUAL" : `${location}`,
           description: `${eventDescription}`,
-          imageURL: imageURL,
+          imageURL: newImageURL,
           startDate: startDateTime,
           endDate: endDateTime,
           capacity: +volunteerSignUpCap,
@@ -177,6 +179,7 @@ const EventForm = ({
           location,
           volunteerSignUpCap,
           eventDescription,
+          imageURL,
           startDate,
           startTime,
           endTime,
@@ -184,19 +187,16 @@ const EventForm = ({
         const userid = await fetchUserIdFromDatabase(user?.email as string);
         const startDateTime = convertToISO(startTime, startDate);
         const endDateTime = convertToISO(endTime, startDate);
-        let imageURL = null;
-        if (typeof eventId === "string") {
-          imageURL = await fetchImageURLFromDB(eventId); // Assign imageURL to previous URL.
-        }
+        let newImageURL = imageURL;
         if (selectedFile) {
-          imageURL = await uploadImage(userid, selectedFile); // Update URL if there is any.
+          newImageURL = await uploadImageToFirebase(userid, selectedFile); // Update URL if there is any.
         }
 
         const { response } = await api.put(`/events/${eventId}`, {
           name: `${eventName}`,
           location: status === 0 ? "VIRTUAL" : `${location}`,
           description: `${eventDescription}`,
-          imageURL: imageURL,
+          imageURL: newImageURL,
           startDate: startDateTime,
           endDate: endDateTime,
           capacity: +volunteerSignUpCap,

--- a/frontend/src/components/organisms/EventForm.tsx
+++ b/frontend/src/components/organisms/EventForm.tsx
@@ -240,8 +240,7 @@ const EventForm = ({
       <Snackbar
         variety="error"
         open={errorNotificationOpen}
-        onClose={() => setErrorNotificationOpen(false)}
-      >
+        onClose={() => setErrorNotificationOpen(false)}>
         Error: {errorMessage}
       </Snackbar>
 
@@ -251,8 +250,7 @@ const EventForm = ({
             ? handleSubmit(handleCreateEvent)
             : handleSubmit(handleEditEvent)
         }
-        className="space-y-4"
-      >
+        className="space-y-4">
         <div className="font-bold text-3xl">
           {eventType == "create" ? "Create Event" : "Edit Event"}
         </div>
@@ -323,8 +321,7 @@ const EventForm = ({
               defaultValue={
                 eventDetails?.mode === "VIRTUAL" ? "Virtual" : "In_Person"
               }
-              sx={{ borderRadius: 2, borderColor: "primary.main" }}
-            >
+              sx={{ borderRadius: 2, borderColor: "primary.main" }}>
               <FormControlLabel
                 value="Virtual"
                 control={<Radio />}
@@ -394,12 +391,22 @@ const EventForm = ({
             })}
           />
         </div>
-        <Dropzone
-          setError={setDropzoneError}
-          label="Event Image"
-          selectedFile={selectedFile}
-          setSelectedFile={setSelectedFile}
+        <Controller
+          name="imageURL"
+          control={control}
+          rules={{ required: { value: true, message: "Required" } }}
+          render={({ field }) => (
+            <Dropzone
+              setError={setDropzoneError}
+              label="Event Image"
+              selectedFile={selectedFile}
+              setSelectedFile={setSelectedFile}
+              {...field}
+              defaultValue={eventDetails?.imageURL}
+            />
+          )}
         />
+
         <TextCopy
           label="RSVP Link Image"
           text={
@@ -437,8 +444,7 @@ const EventForm = ({
                 <Button
                   type="submit"
                   loading={editEventPending}
-                  disabled={editEventPending}
-                >
+                  disabled={editEventPending}>
                   Save changes
                 </Button>
               </div>

--- a/frontend/src/components/organisms/EventForm.tsx
+++ b/frontend/src/components/organisms/EventForm.tsx
@@ -142,10 +142,9 @@ const EventForm = ({
       const startDateTime = convertToISO(startTime, startDate);
       const endDateTime = convertToISO(endTime, startDate);
 
-      const buffer = await selectedFile?.arrayBuffer();
-      let eventImageURL = "";
-      if (!(buffer === undefined)) {
-        eventImageURL = await uploadImage(userid, buffer);
+      let eventImageURL = ""; // If no image, default to original image.
+      if (selectedFile) {
+        eventImageURL = await uploadImage(userid, selectedFile);
       }
 
       const { response } = await api.post("/events", {
@@ -406,55 +405,22 @@ const EventForm = ({
         <div>
           {eventType == "create" ? (
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-              {/* TODO: delete this button */}
+              {/* TODO: delete this button 
               <button
                 onClick={async () => {
                   const userid = await fetchUserIdFromDatabase(
                     user?.email as string
                   );
-                  console.log(await selectedFile?.arrayBuffer());
-                  const buffer = await selectedFile?.arrayBuffer();
+                  // console.log(await selectedFile?.arrayBuffer());
+                  // const buffer = await selectedFile?.arrayBuffer();
                   let eventImageURL = "";
-                  if (!(buffer === undefined)) {
-                    eventImageURL = await uploadImage(userid, buffer);
+                  if (selectedFile) {
+                    eventImageURL = await uploadImage(userid, selectedFile);
                   }
                   console.log(eventImageURL);
                 }}
               >
                 aasdf
-              </button>
-              {/*
-              <button
-                onClick={async () => {
-                  const userid = await fetchUserIdFromDatabase(
-                    user?.email as string
-                  );
-
-                  if (!selectedFile) {
-                    console.error("No file selected");
-                    return;
-                  }
-
-                  const formData = new FormData();
-                  formData.append("image", selectedFile);
-                  formData.append("userID", userid); 
-
-                  fetch("/upload-image", {
-                    // This should match the path your router handles
-                    method: "POST",
-                    body: formData,
-                  })
-                    .then((response) => response.json())
-                    .then((data) => {
-                      console.log("Success:", data);
-                      const eventImageURL = data.url; 
-                    })
-                    .catch((error) => {
-                      console.error("Error:", error);
-                    });
-                }}
-              >
-                Upload Image
               </button>*/}
               <div className="order-1 sm:order-2">
                 <Button loading={isPending} disabled={isPending} type="submit">

--- a/frontend/src/components/organisms/EventForm.tsx
+++ b/frontend/src/components/organisms/EventForm.tsx
@@ -21,6 +21,7 @@ import {
   convertToISO,
   fetchUserIdFromDatabase,
   uploadImage,
+  fetchImageURLFromDB,
 } from "@/utils/helpers";
 import { api } from "@/utils/api";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
@@ -139,9 +140,9 @@ const EventForm = ({
       const userid = await fetchUserIdFromDatabase(user?.email as string);
       const startDateTime = convertToISO(startTime, startDate);
       const endDateTime = convertToISO(endTime, startDate);
-      let eventImageURL = "";
+      let imageURL = null;
       if (selectedFile) {
-        eventImageURL = await uploadImage(userid, selectedFile);
+        imageURL = await uploadImage(userid, selectedFile);
       }
 
       const { response } = await api.post("/events", {
@@ -150,7 +151,7 @@ const EventForm = ({
           name: `${eventName}`,
           location: status === 0 ? "VIRTUAL" : `${location}`,
           description: `${eventDescription}`,
-          imageURL: eventImageURL,
+          imageURL: imageURL,
           startDate: startDateTime,
           endDate: endDateTime,
           capacity: +volunteerSignUpCap,
@@ -183,16 +184,19 @@ const EventForm = ({
         const userid = await fetchUserIdFromDatabase(user?.email as string);
         const startDateTime = convertToISO(startTime, startDate);
         const endDateTime = convertToISO(endTime, startDate);
-        let eventImageURL = "";
+        let imageURL = null;
+        if (typeof eventId === "string") {
+          imageURL = await fetchImageURLFromDB(eventId); // Assign imageURL to previous URL.
+        }
         if (selectedFile) {
-          eventImageURL = await uploadImage(userid, selectedFile);
+          imageURL = await uploadImage(userid, selectedFile); // Update URL if there is any.
         }
 
         const { response } = await api.put(`/events/${eventId}`, {
           name: `${eventName}`,
           location: status === 0 ? "VIRTUAL" : `${location}`,
           description: `${eventDescription}`,
-          imageURL: eventImageURL,
+          imageURL: imageURL,
           startDate: startDateTime,
           endDate: endDateTime,
           capacity: +volunteerSignUpCap,

--- a/frontend/src/components/organisms/EventForm.tsx
+++ b/frontend/src/components/organisms/EventForm.tsx
@@ -43,7 +43,6 @@ type FormValues = {
   location: string;
   volunteerSignUpCap: string;
   eventDescription: string;
-  eventImage: string;
   rsvpLinkImage: string;
   startDate: Date;
   startTime: Date;
@@ -107,7 +106,6 @@ const EventForm = ({
             location: eventDetails.location,
             volunteerSignUpCap: eventDetails.volunteerSignUpCap,
             eventDescription: eventDetails.eventDescription,
-            eventImage: eventDetails.eventImage,
             rsvpLinkImage: eventDetails.rsvpLinkImage,
             startDate: eventDetails.startDate,
             startTime: eventDetails.startTime,
@@ -141,8 +139,7 @@ const EventForm = ({
       const userid = await fetchUserIdFromDatabase(user?.email as string);
       const startDateTime = convertToISO(startTime, startDate);
       const endDateTime = convertToISO(endTime, startDate);
-
-      let eventImageURL = ""; // If no image, default to original image.
+      let eventImageURL = "";
       if (selectedFile) {
         eventImageURL = await uploadImage(userid, selectedFile);
       }
@@ -179,18 +176,23 @@ const EventForm = ({
           location,
           volunteerSignUpCap,
           eventDescription,
-          eventImage,
           startDate,
           startTime,
           endTime,
         } = data;
+        const userid = await fetchUserIdFromDatabase(user?.email as string);
         const startDateTime = convertToISO(startTime, startDate);
         const endDateTime = convertToISO(endTime, startDate);
+        let eventImageURL = "";
+        if (selectedFile) {
+          eventImageURL = await uploadImage(userid, selectedFile);
+        }
+
         const { response } = await api.put(`/events/${eventId}`, {
           name: `${eventName}`,
           location: status === 0 ? "VIRTUAL" : `${location}`,
           description: `${eventDescription}`,
-          imageURL: eventImage,
+          imageURL: eventImageURL,
           startDate: startDateTime,
           endDate: endDateTime,
           capacity: +volunteerSignUpCap,
@@ -405,23 +407,6 @@ const EventForm = ({
         <div>
           {eventType == "create" ? (
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-              {/* TODO: delete this button 
-              <button
-                onClick={async () => {
-                  const userid = await fetchUserIdFromDatabase(
-                    user?.email as string
-                  );
-                  // console.log(await selectedFile?.arrayBuffer());
-                  // const buffer = await selectedFile?.arrayBuffer();
-                  let eventImageURL = "";
-                  if (selectedFile) {
-                    eventImageURL = await uploadImage(userid, selectedFile);
-                  }
-                  console.log(eventImageURL);
-                }}
-              >
-                aasdf
-              </button>*/}
               <div className="order-1 sm:order-2">
                 <Button loading={isPending} disabled={isPending} type="submit">
                   Create

--- a/frontend/src/components/organisms/ViewEvents.tsx
+++ b/frontend/src/components/organisms/ViewEvents.tsx
@@ -63,7 +63,7 @@ const UpcomingEvents = () => {
           endDate: event["endDate"],
           role: "Supervisor",
           hours: eventHours(event["startDate"], event["endDate"]),
-          img_src: event["imageURL"],
+          imageURL: event["imageURL"],
         };
       }
     ) || [];

--- a/frontend/src/pages/events/[eventid]/edit.tsx
+++ b/frontend/src/pages/events/[eventid]/edit.tsx
@@ -13,7 +13,7 @@ type eventData = {
   location: string;
   volunteerSignUpCap: string;
   eventDescription: string;
-  eventImage: string;
+  imageURL: string;
   rsvpLinkImage: string;
   startDate: Date;
   endDate: Date;
@@ -41,7 +41,7 @@ const EditEvent = () => {
     location: data?.location,
     volunteerSignUpCap: data?.capacity,
     eventDescription: data?.description,
-    eventImage: data?.eventImage || "",
+    imageURL: data?.imageURL || "",
     rsvpLinkImage: data?.rsvpLinkImage || "",
     startDate: data?.startDate,
     endDate: data?.endDate,

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -179,24 +179,21 @@ export const formatRoleOrStatus = (str: string) => {
 /**
  * Upload image to firebase
  * @param userID          - The userID of who uploads the image
- * @param imageArrayByte  - The image array byte to upload
+ * @param image           - The image file to upload
  * @returns The string URL to the event.
  */
-export const uploadImage = async (
-  userID: string | null,
-  imageArrayByte: ArrayBuffer
-) => {
+export const uploadImage = async (userID: string | null, image: File) => {
   if (!userID) {
     console.error("No eventId provided");
     return "";
   }
 
+  const fileExtension = image.name.slice(image.name.lastIndexOf("."));
   const currentTime = Date.now();
-  const refString = `${userID}_${currentTime}`;
-  console.log(refString);
+  const refString = `${userID}_${currentTime}${fileExtension}`;
   const storage = getStorage();
   const imageRef = ref(storage, refString);
-  const uploadTask = uploadBytesResumable(imageRef, imageArrayByte);
+  const uploadTask = uploadBytesResumable(imageRef, image);
 
   // Retrieve the download URL
   try {

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -207,3 +207,13 @@ export const uploadImage = async (userID: string | null, image: File) => {
     return "";
   }
 };
+
+/**
+ * This functions performs a search in the DB based on the eventid.
+ * @param eventid is eventid
+ * @returns image URL of previous save of this event
+ */
+export const fetchImageURLFromDB = async (eventid: string) => {
+  const { data } = await api.get(`/events/${eventid}`);
+  return data["data"]["imageURL"];
+};

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -182,9 +182,12 @@ export const formatRoleOrStatus = (str: string) => {
  * @param image           - The image file to upload
  * @returns The string URL to the event.
  */
-export const uploadImage = async (userID: string | null, image: File) => {
+export const uploadImageToFirebase = async (
+  userID: string | null,
+  image: File
+) => {
   if (!userID) {
-    console.error("No eventId provided");
+    console.error("No userID provided");
     return "";
   }
 
@@ -198,22 +201,11 @@ export const uploadImage = async (userID: string | null, image: File) => {
   // Retrieve the download URL
   try {
     // Wait for the upload to complete and retrieve the download URL
-    await uploadTask.then(); // Ensures the upload completes before proceeding
+    await uploadTask; // Ensures the upload completes before proceeding
     const downloadURL = await getDownloadURL(uploadTask.snapshot.ref);
-    console.log("File available at", downloadURL);
     return downloadURL;
   } catch (error) {
     console.error("Upload failed:", error);
     return "";
   }
-};
-
-/**
- * This functions performs a search in the DB based on the eventid.
- * @param eventid is eventid
- * @returns image URL of previous save of this event
- */
-export const fetchImageURLFromDB = async (eventid: string) => {
-  const { data } = await api.get(`/events/${eventid}`);
-  return data["data"]["imageURL"];
 };


### PR DESCRIPTION
## Summary

<!-- Summarize your changes here. -->

Allow users to upload image to Firebase and store said image URL on Prisma when create/edit event. If no image provided, the display will show default image. Once stored, the image should be displayed appropriately on event card. If a user opts to edit an event without choosing a new image, the event will revert to its previous image.

![image](https://github.com/cornellh4i/lagos-volunteers/assets/105695780/453caa7e-18f4-418f-9064-f605bcf6f56b)

## Testing

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->
We tested by manually creating and editing events, replacing images to see each event update its image appropriately.

## Notes

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->
