### PR TITLE
Prevent MDX editor from lazy loading

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  transpilePackages: ["@mdxeditor/editor"],
 };
 
 module.exports = nextConfig;

--- a/frontend/src/components/organisms/About.tsx
+++ b/frontend/src/components/organisms/About.tsx
@@ -11,11 +11,7 @@ import Markdown from "react-markdown";
 import UploadIcon from "@mui/icons-material/Upload";
 import EditIcon from "@mui/icons-material/Edit";
 import { useAuth } from "@/utils/AuthContext";
-import dynamic from "next/dynamic";
-
-const EditorComp = dynamic(() => import("@/components/atoms/Editor"), {
-  ssr: false,
-});
+import EditorComp from "@/components/atoms/Editor";
 
 type modalBodyProps = {
   handleModal: () => void;

--- a/frontend/src/components/organisms/EventForm.tsx
+++ b/frontend/src/components/organisms/EventForm.tsx
@@ -25,11 +25,7 @@ import {
 import { api } from "@/utils/api";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import Dropzone from "../atoms/Dropzone";
-import dynamic from "next/dynamic";
-
-const EditorComp = dynamic(() => import("@/components/atoms/Editor"), {
-  ssr: false,
-});
+import EditorComp from "@/components/atoms/Editor";
 
 interface EventFormProps {
   eventId?: string | string[] | undefined;


### PR DESCRIPTION
## Summary

MDX Editor currently lazy loads which looks bad since there's a pause before the component appears. From the MDX docs [here](https://mdxeditor.dev/editor/docs/getting-started), dynamic import is not actually necessary in the pages router, so I'm importing it normally instead.

## Testing

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

## Notes

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->