### PR TITLE
Prevent event creation in the past

### DIFF
--- a/frontend/src/components/atoms/DatePicker.tsx
+++ b/frontend/src/components/atoms/DatePicker.tsx
@@ -20,9 +20,6 @@ const CustomDatePicker = forwardRef(
     { label, error = "", value, ...props }: DatePickerProps,
     ref: Ref<HTMLInputElement>
   ) => {
-    const today = dayjs();
-    const tomorrow = dayjs().add(1, "day");
-
     return (
       <div>
         <div className="mb-1">{label}</div>

--- a/frontend/src/components/atoms/DatePicker.tsx
+++ b/frontend/src/components/atoms/DatePicker.tsx
@@ -20,6 +20,9 @@ const CustomDatePicker = forwardRef(
     { label, error = "", value, ...props }: DatePickerProps,
     ref: Ref<HTMLInputElement>
   ) => {
+    const today = dayjs();
+    const tomorrow = dayjs().add(1, "day");
+
     return (
       <div>
         <div className="mb-1">{label}</div>
@@ -39,7 +42,7 @@ const CustomDatePicker = forwardRef(
             ref={ref}
             format="DD/MM/YYYY"
             defaultValue={value ? dayjs(value) : undefined}
-            disablePast={true}
+            minDate={tomorrow}
             {...props}
           />
         </LocalizationProvider>

--- a/frontend/src/components/atoms/DatePicker.tsx
+++ b/frontend/src/components/atoms/DatePicker.tsx
@@ -42,7 +42,7 @@ const CustomDatePicker = forwardRef(
             ref={ref}
             format="DD/MM/YYYY"
             defaultValue={value ? dayjs(value) : undefined}
-            minDate={tomorrow}
+            disablePast={true}
             {...props}
           />
         </LocalizationProvider>

--- a/frontend/src/components/atoms/TimePicker.tsx
+++ b/frontend/src/components/atoms/TimePicker.tsx
@@ -1,17 +1,14 @@
 import React, { forwardRef, Ref } from "react";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
-import { TimeField } from "@mui/x-date-pickers/TimeField";
-import { IconButton } from "@mui/material";
-import { InputAdornment } from "@mui/material";
-import { AccessTime } from "@mui/icons-material";
-import dayjs from "dayjs";
 import { TimePicker } from "@mui/x-date-pickers/TimePicker";
+import dayjs from "dayjs";
 
 interface TimePickerProps {
   label: string;
   value?: string;
   error?: string;
+  disablePast?: boolean;
   [key: string]: any;
 }
 
@@ -21,7 +18,13 @@ interface TimePickerProps {
  */
 const CustomTimePicker = forwardRef(
   (
-    { label, value, error = "", ...props }: TimePickerProps,
+    {
+      label,
+      value,
+      error = "",
+      disablePast = false,
+      ...props
+    }: TimePickerProps,
     ref: Ref<HTMLInputElement>
   ) => {
     return (
@@ -40,7 +43,7 @@ const CustomTimePicker = forwardRef(
             label=""
             defaultValue={value ? dayjs(value) : undefined}
             ref={ref}
-            disablePast={true}
+            disablePast={disablePast}
             {...props}
           />
         </LocalizationProvider>

--- a/frontend/src/components/atoms/TimePicker.tsx
+++ b/frontend/src/components/atoms/TimePicker.tsx
@@ -6,6 +6,7 @@ import { IconButton } from "@mui/material";
 import { InputAdornment } from "@mui/material";
 import { AccessTime } from "@mui/icons-material";
 import dayjs from "dayjs";
+import { TimePicker } from "@mui/x-date-pickers/TimePicker";
 
 interface TimePickerProps {
   label: string;
@@ -27,7 +28,7 @@ const CustomTimePicker = forwardRef(
       <div>
         <div className="mb-1">{label}</div>
         <LocalizationProvider dateAdapter={AdapterDayjs}>
-          <TimeField
+          <TimePicker
             sx={{
               "& .MuiInputBase-root": {
                 borderRadius: "8px",
@@ -36,24 +37,10 @@ const CustomTimePicker = forwardRef(
                 height: "9px",
               },
             }}
-            fullWidth
             label=""
             defaultValue={value ? dayjs(value) : undefined}
-            InputProps={{
-              endAdornment: (
-                <InputAdornment position="end">
-                  <IconButton
-                    className="cursor-default"
-                    disableRipple
-                    edge="end"
-                  >
-                    <AccessTime />
-                  </IconButton>
-                </InputAdornment>
-              ),
-            }}
-            slotProps={{ textField: { error: error !== "" } }}
             ref={ref}
+            disablePast={true}
             {...props}
           />
         </LocalizationProvider>

--- a/frontend/src/components/organisms/EventForm.tsx
+++ b/frontend/src/components/organisms/EventForm.tsx
@@ -243,21 +243,27 @@ const EventForm = ({
 
   /** Helper for handling creating events */
   const handleCreateEvent: SubmitHandler<FormValues> = async (data) => {
-    try {
-      await handleCreateNewEvent(data);
-    } catch (error) {
-      setErrorNotificationOpen(true);
-      setErrorMessage("We were unable to create this event. Please try again");
+    if (timeAndDateValidation()) {
+      try {
+        await handleCreateNewEvent(data);
+      } catch (error) {
+        setErrorNotificationOpen(true);
+        setErrorMessage(
+          "We were unable to create this event. Please try again"
+        );
+      }
     }
   };
 
   /** Helper for handling editing events */
   const handleEditEvent: SubmitHandler<FormValues> = async (data) => {
-    try {
-      await handleEditEventAsync(data);
-    } catch (error) {
-      setErrorNotificationOpen(true);
-      setErrorMessage("We were unable to edit this event. Please try again");
+    if (timeAndDateValidation()) {
+      try {
+        await handleEditEventAsync(data);
+      } catch (error) {
+        setErrorNotificationOpen(true);
+        setErrorMessage("We were unable to edit this event. Please try again");
+      }
     }
   };
 
@@ -268,6 +274,20 @@ const EventForm = ({
     } catch (error) {
       setErrorNotificationOpen(true);
       setErrorMessage("We were unable to cancel this event. Please try again");
+    }
+  };
+
+  /** Performs validation to ensure event starts after current time */
+  const timeAndDateValidation = () => {
+    const { startTime, startDate } = getValues();
+    const startDateTime = convertToISO(startTime, startDate);
+    if (new Date(startDateTime) <= new Date()) {
+      setErrorNotificationOpen(true);
+      setErrorMessage("Created event cannot be in the past.");
+      return false;
+    } else {
+      setErrorMessage(null);
+      return true;
     }
   };
 


### PR DESCRIPTION
## Summary

Fixes a current bug where supervisors can create events that are in the past if they happen on the same day if they select a time that is earlier than now (e.g. if today is 4/13 5:00 pm, supervisors can still create an even that happens on 4/13 from 8:00 am to 9:00 am). Solution: make the minimum event date tomorrow (also means we don't need to do more cumbersome date validation).

## Testing

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

## Notes

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->