### PR TITLE
Prevent past events from being edited

### DIFF
--- a/backend/src/events/controllers.ts
+++ b/backend/src/events/controllers.ts
@@ -183,6 +183,14 @@ const getEvents = async (
  * @returns promise with eventID or error.
  */
 const updateEvent = async (eventID: string, event: Event) => {
+  const eventDetails = await getEvent(eventID);
+  const currentDate = new Date();
+  if (eventDetails) {
+    if (eventDetails.startDate < currentDate) {
+      return Promise.reject("Event has already started");
+    }
+  }
+
   return prisma.event.update({
     where: {
       id: eventID,

--- a/frontend/src/components/organisms/EventForm.tsx
+++ b/frontend/src/components/organisms/EventForm.tsx
@@ -46,9 +46,9 @@ type FormValues = {
   eventDescription: string;
   imageURL: string;
   rsvpLinkImage: string;
-  startDate: string;
-  startTime: string;
-  endTime: string;
+  startDate: Date;
+  startTime: Date;
+  endTime: Date;
   mode: string;
 };
 

--- a/frontend/src/components/organisms/EventForm.tsx
+++ b/frontend/src/components/organisms/EventForm.tsx
@@ -26,6 +26,7 @@ import { api } from "@/utils/api";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import Dropzone from "../atoms/Dropzone";
 import dynamic from "next/dynamic";
+import Alert from "../atoms/Alert";
 
 const EditorComp = dynamic(() => import("@/components/atoms/Editor"), {
   ssr: false,
@@ -45,9 +46,9 @@ type FormValues = {
   eventDescription: string;
   imageURL: string;
   rsvpLinkImage: string;
-  startDate: Date;
-  startTime: Date;
-  endTime: Date;
+  startDate: string;
+  startTime: string;
+  endTime: string;
   mode: string;
 };
 
@@ -234,6 +235,12 @@ const EventForm = ({
     }
   };
 
+  /** Edit event "Save changes" button should be disabled if event is in the past */
+  const currentDate = new Date();
+  const disableEditEvent = eventDetails
+    ? new Date(eventDetails?.startDate) < currentDate
+    : false;
+
   return (
     <>
       {/* Error component */}
@@ -256,6 +263,15 @@ const EventForm = ({
         <div className="font-bold text-3xl">
           {eventType == "create" ? "Create Event" : "Edit Event"}
         </div>
+
+        {/* Alert for when the event cannot be edited because it's in the past */}
+        {eventType == "edit" && disableEditEvent && (
+          <Alert variety="error">
+            This event is in the past, so you are not able to make changes to
+            the event.
+          </Alert>
+        )}
+
         <div className="grid grid-cols-1 col-span-2">
           <TextField
             label="Event Name"
@@ -433,13 +449,15 @@ const EventForm = ({
               </div>
               {/* TODO: Add functionality */}
               <div className="sm:col-start-7 sm:col-span-3">
-                <Button variety="error">Cancel event</Button>
+                <Button disabled={disableEditEvent} variety="error">
+                  Cancel event
+                </Button>
               </div>
               <div className="order-first sm:order-last sm:col-start-10 sm:col-span-3">
                 <Button
                   type="submit"
                   loading={editEventPending}
-                  disabled={editEventPending}
+                  disabled={editEventPending || disableEditEvent}
                 >
                   Save changes
                 </Button>

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -75,7 +75,7 @@ export const formatDateString = (dateString: string) => {
  * @param inputDate is the inputDate
  * @returns the ISO string
  */
-export const convertToISO = (inputTime: Date, inputDate: Date) => {
+export const convertToISO = (inputTime: string, inputDate: string) => {
   const date = format(new Date(inputDate), "yyyy-MM-dd");
   const time = format(new Date(inputTime), "HH:mm:ss");
 

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -75,7 +75,7 @@ export const formatDateString = (dateString: string) => {
  * @param inputDate is the inputDate
  * @returns the ISO string
  */
-export const convertToISO = (inputTime: string, inputDate: string) => {
+export const convertToISO = (inputTime: Date, inputDate: Date) => {
   const date = format(new Date(inputDate), "yyyy-MM-dd");
   const time = format(new Date(inputTime), "HH:mm:ss");
 

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -75,7 +75,10 @@ export const formatDateString = (dateString: string) => {
  * @param inputDate is the inputDate
  * @returns the ISO string
  */
-export const convertToISO = (inputTime: Date, inputDate: Date) => {
+export const convertToISO = (
+  inputTime: Date | string,
+  inputDate: Date | string
+) => {
   const date = format(new Date(inputDate), "yyyy-MM-dd");
   const time = format(new Date(inputTime), "HH:mm:ss");
 


### PR DESCRIPTION
## Summary

When a supervisor tries to edit an event that happened in the past, the Save changes button and Cancel event button are disabled, and an alert is shown instead.

## Testing

![image](https://github.com/cornellh4i/lagos-volunteers/assets/48730262/f88f7ab4-fef0-4616-80e0-6b1384d3cda9)

## Notes

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->