### PR TITLE
Prevent registration and cancellation for past events

### DIFF
--- a/frontend/src/components/organisms/EventCardCancel.tsx
+++ b/frontend/src/components/organisms/EventCardCancel.tsx
@@ -14,6 +14,7 @@ import { useForm, SubmitHandler } from "react-hook-form";
 interface EventCardCancelProps {
   attendeeId: string;
   eventId: string;
+  date: Date;
 }
 
 interface modalProps {
@@ -58,7 +59,11 @@ const ModalBody = ({ handleClose, mutateFn }: modalProps) => {
   );
 };
 
-const EventCardCancel = ({ eventId, attendeeId }: EventCardCancelProps) => {
+const EventCardCancel = ({
+  eventId,
+  attendeeId,
+  date,
+}: EventCardCancelProps) => {
   const { user } = useAuth();
   const queryClient = useQueryClient();
 
@@ -110,6 +115,10 @@ const EventCardCancel = ({ eventId, attendeeId }: EventCardCancelProps) => {
     setOpen(!open);
   };
 
+  /** Register button should be disabled if event is in the past */
+  const currentDate = new Date();
+  const disableCancelEvent = date < currentDate;
+
   return (
     <>
       <Modal
@@ -121,7 +130,9 @@ const EventCardCancel = ({ eventId, attendeeId }: EventCardCancelProps) => {
       <Card>
         <div className="font-semibold text-2xl">You're registered</div>
         <div className="mt-5" />
-        <div className="font-semibold text-lg">No longer able to attend?</div>
+        <div className="font-semibold text-lg mb-2">
+          No longer able to attend?
+        </div>
         <IconText icon={<AccessTimeFilledIcon />}>
           {/* TODO: Update how many hours left */}
           <div>4 hours left to cancel registration</div>
@@ -142,12 +153,17 @@ const EventCardCancel = ({ eventId, attendeeId }: EventCardCancelProps) => {
             {...register("cancelReason", {
               required: { value: true, message: "Required" },
             })}
+            disabled={disableCancelEvent}
             onChange={(e: any) => setCancelationMessage(e.target.value)}
           />
           <div className="mt-3" />
-          <Button type="submit" variety="error">
-            Cancel registration
-          </Button>
+          {disableCancelEvent ? (
+            <Button disabled>The event has concluded.</Button>
+          ) : (
+            <Button type="submit" variety="error">
+              Cancel registration
+            </Button>
+          )}
         </form>
       </Card>
     </>

--- a/frontend/src/components/organisms/EventCardRegister.tsx
+++ b/frontend/src/components/organisms/EventCardRegister.tsx
@@ -5,13 +5,19 @@ import Button from "../atoms/Button";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/utils/api";
 import { useAuth } from "@/utils/AuthContext";
+import Alert from "../atoms/Alert";
 
 interface EventRegisterCardProps {
   attendeeId: string;
   eventId: string;
+  date: Date;
 }
 
-const EventCardRegister = ({ eventId, attendeeId }: EventRegisterCardProps) => {
+const EventCardRegister = ({
+  eventId,
+  attendeeId,
+  date,
+}: EventRegisterCardProps) => {
   const { user } = useAuth();
   const queryClient = useQueryClient();
 
@@ -35,6 +41,10 @@ const EventCardRegister = ({ eventId, attendeeId }: EventRegisterCardProps) => {
     },
   });
 
+  /** Register button should be disabled if event is in the past */
+  const currentDate = new Date();
+  const disableRegisterEvent = date < currentDate;
+
   return (
     <Card>
       <div className="font-semibold text-2xl">Register for this event</div>
@@ -48,16 +58,21 @@ const EventCardRegister = ({ eventId, attendeeId }: EventRegisterCardProps) => {
       <div className="mt-3" />
       <CustomCheckbox
         label="I agree to the terms and conditions"
+        disabled={disableRegisterEvent}
         onChange={() => setIsChecked(!isChecked)}
       />
       <div className="mt-3" />
-      <Button
-        onClick={handleEventResgistration}
-        disabled={!isChecked}
-        loading={isPending}
-      >
-        Register
-      </Button>
+      {disableRegisterEvent ? (
+        <Button disabled>The event has concluded.</Button>
+      ) : (
+        <Button
+          onClick={handleEventResgistration}
+          disabled={!isChecked}
+          loading={isPending}
+        >
+          Register
+        </Button>
+      )}
     </Card>
   );
 };

--- a/frontend/src/components/organisms/ViewEventDetails.tsx
+++ b/frontend/src/components/organisms/ViewEventDetails.tsx
@@ -22,6 +22,7 @@ import EventCardCancel from "./EventCardCancel";
 import Markdown from "react-markdown";
 import DefaultTemplate from "../templates/DefaultTemplate";
 import FetchDataError from "./FetchDataError";
+import EventDetails from "./EventDetails";
 
 interface ViewEventDetailsProps {}
 
@@ -132,9 +133,17 @@ const ViewEventDetails = () => {
             {userHasCanceledAttendance ? (
               <EventCardCancelConfirmation />
             ) : eventAttendance ? (
-              <EventCardCancel eventId={eventid} attendeeId={userid} />
+              <EventCardCancel
+                eventId={eventid}
+                attendeeId={userid}
+                date={new Date(eventData.startDate)}
+              />
             ) : (
-              <EventCardRegister eventId={eventid} attendeeId={userid} />
+              <EventCardRegister
+                eventId={eventid}
+                attendeeId={userid}
+                date={new Date(eventData.startDate)}
+              />
             )}
           </div>
         )


### PR DESCRIPTION
## Summary

Volunteers can no longer register for / cancel past events.

## Testing

![image](https://github.com/cornellh4i/lagos-volunteers/assets/48730262/5b2333ab-a65f-4a32-b671-1ff0d0827d9a)

![image](https://github.com/cornellh4i/lagos-volunteers/assets/48730262/57281a6c-fa38-4693-8d83-5763b7b12401)


## Notes

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->