### PR TITLE
Profile account settings (redesign-profile-fullstack)

### DIFF
--- a/frontend/src/components/organisms/ChangePasswordForm.tsx
+++ b/frontend/src/components/organisms/ChangePasswordForm.tsx
@@ -1,35 +1,24 @@
 import React, { useState } from "react";
 import Button from "../atoms/Button";
 import TextField from "../atoms/TextField";
-import Checkbox from "../atoms/Checkbox";
 import { auth } from "@/utils/firebase";
 import { useForm, SubmitHandler } from "react-hook-form";
 import { reauthenticateWithCredential, EmailAuthProvider } from "firebase/auth";
 import Snackbar from "../atoms/Snackbar";
-import { api } from "@/utils/api";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { updatePassword } from "firebase/auth";
 import { User } from "firebase/auth";
 
 type FormValues = {
   email: string;
-  firstName: string;
-  lastName: string;
-  phoneNumber: string;
-  // preferredName: string;
   oldPassword: string;
   newPassword: string;
   confirmNewPassword: string;
-  emailNotifications: boolean;
 };
 
 type formData = {
   id: string;
   email: string;
-  firstName: string;
-  lastName: string;
-  phoneNumber: string;
-  nickname: string;
   role?: string;
   status?: string;
   createdAt?: string;
@@ -43,8 +32,6 @@ interface ChangePasswordFormProps {
 }
 
 const ChangePasswordForm = ({ userDetails }: ChangePasswordFormProps) => {
-  const queryClient = useQueryClient();
-
   /** State variables for the notification popups for profile update */
   const [successNotificationOpen, setSuccessNotificationOpen] = useState(false);
   const [errorNotificationOpen, setErrorNotificationOpen] = useState(false);
@@ -85,24 +72,12 @@ const ChangePasswordForm = ({ userDetails }: ChangePasswordFormProps) => {
   } = useForm<FormValues>({
     defaultValues: {
       email: userDetails.email,
-      firstName: userDetails.firstName,
-      lastName: userDetails.lastName,
-      phoneNumber: userDetails.phoneNumber,
       // preferredName: userDetails.nickname,
       oldPassword: "",
       newPassword: "",
       confirmNewPassword: "",
-      emailNotifications: false,
     },
   });
-
-  /** Handles checkbox */
-
-  // TODO: Implement this
-  const [checked, setChecked] = useState(false);
-  const handleCheckbox = () => {
-    setChecked((checked) => !checked);
-  };
 
   /** Tanstack query mutation to reauthenticate the user session */
   const ReAuthenticateUserSession = useMutation({
@@ -124,22 +99,6 @@ const ChangePasswordForm = ({ userDetails }: ChangePasswordFormProps) => {
     mutationFn: async (data: any) => {
       const user = auth.currentUser as User;
       return updatePassword(user, data.newPassword);
-    },
-    retry: false,
-  });
-
-  /** Tanstack query mutation to update the user profile */
-  const updateProfileInDB = useMutation({
-    mutationFn: async (data: any) => {
-      return api.put(`/users/${userDetails.id}/profile`, {
-        firstName: data.firstName,
-        lastName: data.lastName,
-        phoneNumber: data.phoneNumber,
-        // nickname: data.preferredName,
-      });
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["profile"] });
     },
     retry: false,
   });

--- a/frontend/src/components/organisms/ChangePasswordForm.tsx
+++ b/frontend/src/components/organisms/ChangePasswordForm.tsx
@@ -154,6 +154,20 @@ const ChangePasswordForm = ({ userDetails }: ChangePasswordFormProps) => {
               value: 6,
               message: "Password must be at least 6 characters",
             },
+            validate: {
+              hasUpper: (value) =>
+                /.*[A-Z].*/.test(value) ||
+                "Password must contain at least one uppercase letter",
+              hasLower: (value) =>
+                /.*[a-z].*/.test(value) ||
+                "Password must contain at least one lowercase letter",
+              hasNumber: (value) =>
+                /.*[0-9].*/.test(value) ||
+                "Password must contain at least one number",
+              hasSpecialChar: (value) =>
+                /.*[\W_].*/.test(value) ||
+                "Password must contain at least one special character",
+            },
           })}
         />
         <TextField

--- a/frontend/src/components/organisms/ChangePasswordForm.tsx
+++ b/frontend/src/components/organisms/ChangePasswordForm.tsx
@@ -58,7 +58,7 @@ const ChangePasswordForm = ({ userDetails }: ChangePasswordFormProps) => {
       case "too-many-requests":
         return "You have made too many requests to change your password. Please try again later.";
       default:
-        return "Something went wrong. Please try again";
+        return "Something went wrong. Please try again.";
     }
   };
 
@@ -155,20 +155,6 @@ const ChangePasswordForm = ({ userDetails }: ChangePasswordFormProps) => {
               value: 6,
               message: "Password must be at least 6 characters",
             },
-            // validate: {
-            //   hasUpper: (value) =>
-            //     /.*[A-Z].*/.test(value) ||
-            //     "Password must contain at least one uppercase letter",
-            //   hasLower: (value) =>
-            //     /.*[a-z].*/.test(value) ||
-            //     "Password must contain at least one lowercase letter",
-            //   hasNumber: (value) =>
-            //     /.*[0-9].*/.test(value) ||
-            //     "Password must contain at least one number",
-            //   hasSpecialChar: (value) =>
-            //     /.*[\W_].*/.test(value) ||
-            //     "Password must contain at least one special character",
-            // },
           })}
         />
         <TextField

--- a/frontend/src/components/organisms/ChangePasswordForm.tsx
+++ b/frontend/src/components/organisms/ChangePasswordForm.tsx
@@ -72,7 +72,6 @@ const ChangePasswordForm = ({ userDetails }: ChangePasswordFormProps) => {
   } = useForm<FormValues>({
     defaultValues: {
       email: userDetails.email,
-      // preferredName: userDetails.nickname,
       oldPassword: "",
       newPassword: "",
       confirmNewPassword: "",
@@ -169,9 +168,9 @@ const ChangePasswordForm = ({ userDetails }: ChangePasswordFormProps) => {
             },
           })}
         />
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 pt-2">
           <div className="order-1 sm:order-2">
-            <Button type="submit">Change Password</Button>
+            <Button type="submit">Change password</Button>
           </div>
           <div className="order-2 sm:order-1">
             <Button
@@ -182,7 +181,7 @@ const ChangePasswordForm = ({ userDetails }: ChangePasswordFormProps) => {
               }}
               disabled={!isDirty}
             >
-              Cancel
+              Reset changes
             </Button>
           </div>
         </div>

--- a/frontend/src/components/organisms/ProfileForm.tsx
+++ b/frontend/src/components/organisms/ProfileForm.tsx
@@ -2,14 +2,10 @@ import React, { useState } from "react";
 import Button from "../atoms/Button";
 import TextField from "../atoms/TextField";
 import Checkbox from "../atoms/Checkbox";
-import { auth } from "@/utils/firebase";
 import { useForm, SubmitHandler } from "react-hook-form";
-import { reauthenticateWithCredential, EmailAuthProvider } from "firebase/auth";
 import Snackbar from "../atoms/Snackbar";
 import { api } from "@/utils/api";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { updatePassword } from "firebase/auth";
-import { User } from "firebase/auth";
 
 type FormValues = {
   email: string;

--- a/frontend/src/components/organisms/ProfileForm.tsx
+++ b/frontend/src/components/organisms/ProfileForm.tsx
@@ -15,6 +15,7 @@ type FormValues = {
   email: string;
   firstName: string;
   lastName: string;
+  phoneNumber: string;
   // preferredName: string;
   oldPassword: string;
   newPassword: string;
@@ -27,6 +28,7 @@ type formData = {
   email: string;
   firstName: string;
   lastName: string;
+  phoneNumber: string;
   nickname: string;
   role?: string;
   status?: string;
@@ -85,6 +87,7 @@ const ProfileForm = ({ userDetails }: ProfileFormProps) => {
       email: userDetails.email,
       firstName: userDetails.firstName,
       lastName: userDetails.lastName,
+      phoneNumber: userDetails.phoneNumber,
       // preferredName: userDetails.nickname,
       oldPassword: "",
       newPassword: "",
@@ -131,6 +134,7 @@ const ProfileForm = ({ userDetails }: ProfileFormProps) => {
       return api.put(`/users/${userDetails.id}/profile`, {
         firstName: data.firstName,
         lastName: data.lastName,
+        phoneNumber: data.phoneNumber,
         // nickname: data.preferredName,
       });
     },
@@ -176,6 +180,20 @@ const ProfileForm = ({ userDetails }: ProfileFormProps) => {
       {/* Profile form */}
       <form onSubmit={handleSubmit(handleChanges)} className="space-y-4">
         <TextField
+          error={errors.firstName?.message}
+          label="First name"
+          {...register("firstName", {
+            required: { value: true, message: "Required" },
+          })}
+        />
+        <TextField
+          error={errors.lastName?.message}
+          label="Last name"
+          {...register("lastName", {
+            required: { value: true, message: "Required" },
+          })}
+        />
+        <TextField
           error={errors.email?.message}
           label="Email"
           {...register("email", {
@@ -188,17 +206,15 @@ const ProfileForm = ({ userDetails }: ProfileFormProps) => {
           })}
         />
         <TextField
-          error={errors.firstName?.message}
-          label="First name"
-          {...register("firstName", {
+          error={errors.phoneNumber?.message}
+          label="Phone number"
+          {...register("phoneNumber", {
             required: { value: true, message: "Required" },
-          })}
-        />
-        <TextField
-          error={errors.lastName?.message}
-          label="Last name"
-          {...register("lastName", {
-            required: { value: true, message: "Required" },
+            pattern: {
+              value:
+                /^\+?\d{1,4}?[-.\s]?\(?\d{1,3}?\)?[-.\s]?\d{1,4}[-.\s]?\d{1,4}[-.\s]?\d{1,9}$/,
+              message: "Invalid phone number",
+            },
           })}
         />
         {/* <TextField
@@ -226,20 +242,20 @@ const ProfileForm = ({ userDetails }: ProfileFormProps) => {
               value: 6,
               message: "Password must be at least 6 characters",
             },
-            validate: {
-              hasUpper: (value) =>
-                /.*[A-Z].*/.test(value) ||
-                "Password must contain at least one uppercase letter",
-              hasLower: (value) =>
-                /.*[a-z].*/.test(value) ||
-                "Password must contain at least one lowercase letter",
-              hasNumber: (value) =>
-                /.*[0-9].*/.test(value) ||
-                "Password must contain at least one number",
-              hasSpecialChar: (value) =>
-                /.*[\W_].*/.test(value) ||
-                "Password must contain at least one special character",
-            },
+            // validate: {
+            //   hasUpper: (value) =>
+            //     /.*[A-Z].*/.test(value) ||
+            //     "Password must contain at least one uppercase letter",
+            //   hasLower: (value) =>
+            //     /.*[a-z].*/.test(value) ||
+            //     "Password must contain at least one lowercase letter",
+            //   hasNumber: (value) =>
+            //     /.*[0-9].*/.test(value) ||
+            //     "Password must contain at least one number",
+            //   hasSpecialChar: (value) =>
+            //     /.*[\W_].*/.test(value) ||
+            //     "Password must contain at least one special character",
+            // },
           })}
         />
         <TextField

--- a/frontend/src/components/organisms/ProfileForm.tsx
+++ b/frontend/src/components/organisms/ProfileForm.tsx
@@ -207,7 +207,7 @@ const ProfileForm = ({ userDetails }: ProfileFormProps) => {
               }}
               disabled={!isDirty}
             >
-              Cancel
+              Reset changes
             </Button>
           </div>
         </div>

--- a/frontend/src/components/organisms/ProfileForm.tsx
+++ b/frontend/src/components/organisms/ProfileForm.tsx
@@ -47,14 +47,8 @@ const ProfileForm = ({ userDetails }: ProfileFormProps) => {
   const handleErrors = (errors: any) => {
     const errorParsed = errors?.split("/")[1]?.slice(0, -2);
     switch (errorParsed) {
-      case "invalid-email":
-        return "Invalid email address format.";
-      case "user-disabled":
-        return "User with this email has been disabled.";
-      case "user-not-found":
-        return "There is no user with this email address.";
       default:
-        return "Something went wrong. Please try again";
+        return "Something went wrong. Please try again.";
     }
   };
 

--- a/frontend/src/components/organisms/ProfileForm.tsx
+++ b/frontend/src/components/organisms/ProfileForm.tsx
@@ -88,30 +88,6 @@ const ProfileForm = ({ userDetails }: ProfileFormProps) => {
     setChecked((checked) => !checked);
   };
 
-  /** Tanstack query mutation to reauthenticate the user session */
-  const ReAuthenticateUserSession = useMutation({
-    mutationFn: async (data: any) => {
-      const currentUser = auth.currentUser;
-      if (currentUser != null) {
-        const credentials = EmailAuthProvider.credential(
-          data.email,
-          data.oldPassword
-        );
-        return reauthenticateWithCredential(currentUser, credentials);
-      }
-    },
-    retry: false,
-  });
-
-  /** Tanstack query mutation to update user password in Firebase */
-  const updateUserPasswordInFirebase = useMutation({
-    mutationFn: async (data: any) => {
-      const user = auth.currentUser as User;
-      return updatePassword(user, data.newPassword);
-    },
-    retry: false,
-  });
-
   /** Tanstack query mutation to update the user profile */
   const updateProfileInDB = useMutation({
     mutationFn: async (data: any) => {

--- a/frontend/src/pages/profile.tsx
+++ b/frontend/src/pages/profile.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import ProfileForm from "@/components/organisms/ProfileForm";
+import ChangePasswordForm from "@/components/organisms/ChangePasswordForm";
 import CenteredTemplate from "@/components/templates/CenteredTemplate";
 import Banner from "@/components/molecules/Banner";
 import { useAuth } from "@/utils/AuthContext";
@@ -97,9 +98,18 @@ const Profile = () => {
           </div>
         )}
       </Card>
-      <h3 className="text-xl font-normal">My Profile</h3>
+      <h3 className="text-xl font-normal mt-12">My Profile</h3>
       <Card size="medium">
         <ProfileForm
+          userDetails={{
+            ...data.profile,
+            ...data,
+          }}
+        />
+      </Card>
+      <h3 className="text-xl font-normal mt-12">My Account</h3>
+      <Card size="medium">
+        <ChangePasswordForm
           userDetails={{
             ...data.profile,
             ...data,


### PR DESCRIPTION
## Summary

Decouple the profile form so now users can submit profile changes and password changes independently from one another.

![image](https://github.com/cornellh4i/lagos-volunteers/assets/105695780/8f8e46bd-a148-4468-92f6-196df7c4bd59)
![image](https://github.com/cornellh4i/lagos-volunteers/assets/105695780/01d3496c-83ef-40de-ad68-edf7578e7368)
![image](https://github.com/cornellh4i/lagos-volunteers/assets/105695780/0aff3679-272e-4709-bfb9-2a187d1b2ffe)


## Testing

We manually test it out on the front end, then check to see if back end is updated properly.

## Notes

We did comment out validation for strong password during testing, so that might be something that we might want to add again in the future.