### PR TITLE
Fix edit page refresh

### DIFF
--- a/frontend/src/components/organisms/EventForm.tsx
+++ b/frontend/src/components/organisms/EventForm.tsx
@@ -202,7 +202,20 @@ const EventForm = ({
           capacity: +volunteerSignUpCap,
           mode: `${mode}`,
         });
-        return response;
+        const updatedEventData = {
+          id: eventId, // Assuming the server response includes the event ID
+          eventName,
+          location: status === 0 ? "VIRTUAL" : location,
+          volunteerSignUpCap,
+          eventDescription,
+          imageURL: newImageURL,
+          startDate: new Date(startDateTime),
+          startTime: new Date(startDateTime),
+          endTime: new Date(endDateTime),
+          mode: mode,
+        };
+
+        return updatedEventData;
       },
       retry: false,
       onSuccess: (updatedEventData) => {

--- a/frontend/src/components/organisms/EventForm.tsx
+++ b/frontend/src/components/organisms/EventForm.tsx
@@ -206,6 +206,7 @@ const EventForm = ({
       },
       retry: false,
       onSuccess: () => {
+        console.log("Updated event data:");
         queryClient.invalidateQueries({
           queryKey: ["event", eventId],
         });

--- a/frontend/src/components/organisms/EventForm.tsx
+++ b/frontend/src/components/organisms/EventForm.tsx
@@ -205,11 +205,12 @@ const EventForm = ({
         return response;
       },
       retry: false,
-      onSuccess: () => {
-        console.log("Updated event data:");
-        queryClient.invalidateQueries({
-          queryKey: ["event", eventId],
-        });
+      onSuccess: (updatedEventData) => {
+        console.log("Updated event data:", updatedEventData);
+        // queryClient.invalidateQueries({
+        //   queryKey: ["event", eventId],
+        // });
+        queryClient.setQueryData(["event", eventId], updatedEventData);
         localStorage.setItem("eventEdited", "true");
         router.push("/events/view");
       },

--- a/frontend/src/components/organisms/EventForm.tsx
+++ b/frontend/src/components/organisms/EventForm.tsx
@@ -202,8 +202,8 @@ const EventForm = ({
           capacity: +volunteerSignUpCap,
           mode: `${mode}`,
         });
-        const updatedEventData = {
-          id: eventId, // Assuming the server response includes the event ID
+        const updatedEventData = await api.put(`/events/${eventId}`, {
+          id: eventId,
           eventName,
           location: status === 0 ? "VIRTUAL" : location,
           volunteerSignUpCap,
@@ -213,9 +213,9 @@ const EventForm = ({
           startTime: new Date(startDateTime),
           endTime: new Date(endDateTime),
           mode: mode,
-        };
+        });
 
-        return updatedEventData;
+        return response;
       },
       retry: false,
       onSuccess: (updatedEventData) => {


### PR DESCRIPTION
## Summary

We added UpdateEventData that had the latest information in order to populate the data with since it was returning response in which structure of response might not match what React Query expects. We then used UpdateEventData in  the onSuccess function and switched it from invalidateQueries to setQueryData so we update the corresponding query in the React Query cache. 

## Testing

We created a fake event calling Testing event bug that allowed us to experiment and test our code with the edit event function. We also created console.log comments to for updatedEventData to see if the right data was being passed through.

## Notes

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->