### PR TITLE
Added attendee status to past events table

### DIFF
--- a/frontend/src/components/organisms/ViewEvents.tsx
+++ b/frontend/src/components/organisms/ViewEvents.tsx
@@ -39,10 +39,10 @@ const UpcomingEvents = () => {
       const userid = await fetchUserIdFromDatabase(user?.email as string);
       setUserid(userid);
       const upcomingEventsUserRegisteredFor = await api.get(
-        `/events?userid=${userid}&date=upcoming&sort=startDate:desc`
+        `/events?userid=${userid}&date=upcoming&sort=startDate:asc`
       );
       const upcomingEventsUserSupervises = await api.get(
-        `/events?ownerid=${userid}&date=upcoming&sort=startDate:desc`
+        `/events?ownerid=${userid}&date=upcoming&sort=startDate:asc`
       );
       return {
         upcomingRegistered: upcomingEventsUserRegisteredFor.data["data"],
@@ -173,7 +173,7 @@ const PastEvents = () => {
     queryFn: async () => {
       const userid = await fetchUserIdFromDatabase(user?.email as string);
       const pastEventsUserRegisteredFor = await api.get(
-        `/events?userid=${userid}&date=past&limit=${PAGE_SIZE_VOLUNTEER}`
+        `/events?userid=${userid}&date=past&sort=startDate:desc&include=attendees&limit=${PAGE_SIZE_VOLUNTEER}`
       );
       return pastEventsUserRegisteredFor["data"];
     },
@@ -225,6 +225,7 @@ const PastEvents = () => {
       endDate: event["endDate"],
       role: "Volunteer",
       hours: eventHours(event["endDate"], event["startDate"]),
+      attendeeStatus: event["attendees"][0]["attendeeStatus"], //I added this - David
     });
   });
 
@@ -264,7 +265,7 @@ const PastEvents = () => {
         queryKey: ["volunteer_events", paginationModelVolunteer.page + 1],
         queryFn: async () => {
           const pastEventsUserRegisteredFor = await api.get(
-            `/events?userid=${userid}&date=past&limit=${PAGE_SIZE_VOLUNTEER}&after=${cursorVolunteer}`
+            `/events?userid=${userid}&date=past&sort=startDate:desc&include=attendees&limit=${PAGE_SIZE_VOLUNTEER}&after=${cursorVolunteer}`
           );
           return pastEventsUserRegisteredFor["data"];
         },
@@ -324,6 +325,14 @@ const PastEvents = () => {
       field: "hours",
       headerName: "Hours",
       minWidth: 150,
+      renderHeader: (params) => (
+        <div style={{ fontWeight: "bold" }}>{params.colDef.headerName}</div>
+      ),
+    },
+    {
+      field: "attendeeStatus",
+      headerName: "Attendee Status",
+      minWidth: 250,
       renderHeader: (params) => (
         <div style={{ fontWeight: "bold" }}>{params.colDef.headerName}</div>
       ),

--- a/frontend/src/components/organisms/ViewEvents.tsx
+++ b/frontend/src/components/organisms/ViewEvents.tsx
@@ -189,7 +189,7 @@ const PastEvents = () => {
     queryFn: async () => {
       const userid = await fetchUserIdFromDatabase(user?.email as string);
       const pastEventsUserSupervised = await api.get(
-        `/events?ownerid=${userid}&date=past&limit=${PAGE_SIZE_SUPERVISOR}`
+        `/events?ownerid=${userid}&date=past&sort=startDate:desc&limit=${PAGE_SIZE_SUPERVISOR}`
       );
       return pastEventsUserSupervised["data"];
     },
@@ -225,7 +225,7 @@ const PastEvents = () => {
       endDate: event["endDate"],
       role: "Volunteer",
       hours: eventHours(event["endDate"], event["startDate"]),
-      attendeeStatus: event["attendees"][0]["attendeeStatus"], //I added this - David
+      attendeeStatus: event["attendees"][0]["attendeeStatus"],
     });
   });
 
@@ -331,7 +331,7 @@ const PastEvents = () => {
     },
     {
       field: "attendeeStatus",
-      headerName: "Attendee Status",
+      headerName: "Status",
       minWidth: 250,
       renderHeader: (params) => (
         <div style={{ fontWeight: "bold" }}>{params.colDef.headerName}</div>
@@ -339,7 +339,7 @@ const PastEvents = () => {
     },
     {
       field: "role",
-      headerName: "Status",
+      headerName: "Role",
       minWidth: 150,
       renderHeader: (params) => (
         <div style={{ fontWeight: "bold" }}>{params.colDef.headerName}</div>

--- a/frontend/src/components/organisms/ViewEvents.tsx
+++ b/frontend/src/components/organisms/ViewEvents.tsx
@@ -347,7 +347,7 @@ const PastEvents = () => {
     {
       field: "hours",
       headerName: "Hours",
-      minWidth: 150,
+      minWidth: 50,
       renderHeader: (params) => (
         <div style={{ fontWeight: "bold" }}>{params.colDef.headerName}</div>
       ),
@@ -355,7 +355,7 @@ const PastEvents = () => {
     {
       field: "attendeeStatus",
       headerName: "Status",
-      minWidth: 250,
+      minWidth: 150,
       renderHeader: (params) => (
         <div style={{ fontWeight: "bold" }}>{params.colDef.headerName}</div>
       ),

--- a/frontend/src/components/organisms/ViewEvents.tsx
+++ b/frontend/src/components/organisms/ViewEvents.tsx
@@ -9,7 +9,11 @@ import Table from "@/components/molecules/Table";
 import Button from "../atoms/Button";
 import Link from "next/link";
 import { useAuth } from "@/utils/AuthContext";
-import { eventHours, fetchUserIdFromDatabase } from "@/utils/helpers";
+import {
+  convertEnrollmentStatusToString,
+  eventHours,
+  fetchUserIdFromDatabase,
+} from "@/utils/helpers";
 import { Action, ViewEventsEvent } from "@/utils/types";
 import { api } from "@/utils/api";
 import ManageSearchIcon from "@mui/icons-material/ManageSearch";
@@ -228,7 +232,9 @@ const PastEvents = () => {
       endDate: event["endDate"],
       role: "Volunteer",
       hours: eventHours(event["endDate"], event["startDate"]),
-      attendeeStatus: event["attendees"][0]["attendeeStatus"],
+      attendeeStatus: convertEnrollmentStatusToString(
+        event["attendees"][0]["attendeeStatus"]
+      ),
       status: event["status"],
     });
   });

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -212,3 +212,22 @@ export const uploadImageToFirebase = async (
     return "";
   }
 };
+
+/**
+ * Converts the user registration status enum to a display friendly string
+ * @param status is the EnrollmentStatus enum
+ */
+export const convertEnrollmentStatusToString = (status: string) => {
+  switch (status) {
+    case "PENDING":
+      return "Pending";
+    case "CHECKED_IN":
+      return "Checked in";
+    case "CHECKED_OUT":
+      return "Checked out";
+    case "REMOVED":
+      return "Removed";
+    case "CANCELED":
+      return "Canceled";
+  }
+};

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -12,6 +12,7 @@ export type ViewEventsEvent = {
   description?: string;
   capacity?: number;
   imageURL?: string;
+  attendeeStatus?: string;
 };
 
 export type EventData = {


### PR DESCRIPTION
## Summary

<!-- Summarize your changes here. -->

1. In ViewEvents.tsx: made adjustments to endpoints that called the past events volunteers registered for. These adjustments allowed for attendee information to be retrieved as well as sorting events by their start time
2. In types.ts we added an attendeeStatus field to the ViewEventsEvent prop.
3. In ViewEvents.tsx we added a new column to the table that shows the user's attendeeStatus for events

## Testing

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

1. Tested by using postman and looking at prisma database

## Notes

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->
1. None