### PR TITLE
Allow users to manage authentication providers

### DIFF
--- a/frontend/src/components/organisms/ChangePasswordForm.tsx
+++ b/frontend/src/components/organisms/ChangePasswordForm.tsx
@@ -48,7 +48,7 @@ const ChangePasswordForm = ({ userDetails }: ChangePasswordFormProps) => {
       case "user-not-found":
         return "There is no user with this email address.";
       case "wrong-password":
-        return "Old password is incorrect.";
+        return "Current password is incorrect.";
       case "weak-password":
         return "Password must be at least 6 characters.";
       case "invalid-password":
@@ -135,10 +135,19 @@ const ChangePasswordForm = ({ userDetails }: ChangePasswordFormProps) => {
       </Snackbar>
 
       {/* Profile form */}
+      <h3 className="mt-0 mb-4 font-normal">Change your password</h3>
+      <div className="text-sm mb-4">
+        Passwords should meet the following requirements:
+        <ul className="m-0 px-4">
+          <li>At least 6 characters in length</li>
+          <li>Contain a mix of uppercase and lowercase letters</li>
+          <li>Include at least one number and one special character</li>
+        </ul>
+      </div>
       <form onSubmit={handleSubmit(handleChanges)} className="space-y-4">
         <TextField
           type="password"
-          label="Old password"
+          label="Current password"
           error={errors.oldPassword?.message}
           {...register("oldPassword", {
             required: { value: true, message: "Required" },

--- a/frontend/src/components/organisms/LinkEmailPasswordForm.tsx
+++ b/frontend/src/components/organisms/LinkEmailPasswordForm.tsx
@@ -1,0 +1,153 @@
+import React, { useState } from "react";
+import Button from "../atoms/Button";
+import TextField from "../atoms/TextField";
+import { useForm, SubmitHandler } from "react-hook-form";
+import { useRouter } from "next/router";
+import Snackbar from "../atoms/Snackbar";
+import { useAuth } from "@/utils/AuthContext";
+import { linkWithCredential } from "firebase/auth";
+import { EmailAuthProvider } from "firebase/auth";
+
+type FormValues = {
+  password: string;
+  confirmPassword: string;
+};
+
+const LinkEmailPasswordForm = () => {
+  /** State variables for the notification popups */
+  const [successNotificationOpen, setSuccessNotificationOpen] = useState(false);
+  const [errorNotificationOpen, setErrorNotificationOpen] = useState(false);
+
+  const [errorMessage, setErrorMessage] = useState<string>("");
+  const router = useRouter();
+  const { user } = useAuth();
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors },
+  } = useForm<FormValues>();
+
+  const handleErrors = (errors: any) => {
+    const errorParsed = errors?.split("/")[1]?.slice(0, -2);
+    switch (errorParsed) {
+      case "invalid-email":
+        return "Invalid email address format.";
+      case "user-disabled":
+        return "User with this email has been disabled.";
+      case "user-not-found":
+        return "There is no user with this email address.";
+      case "wrong-password":
+        return "Old password is incorrect.";
+      case "weak-password":
+        return "Password must be at least 6 characters.";
+      case "invalid-password":
+        return "Invalid password.";
+      case "requires-recent-login":
+        return "Please reauthenticate to change your password.";
+      case "too-many-requests":
+        return "You have made too many requests to change your password. Please try again later.";
+      case "provider-already-linked":
+        return "Your provider has already been linked.";
+      default:
+        return "Something went wrong. Please try again";
+    }
+  };
+
+  const handleSubmitForm: SubmitHandler<FormValues> = async (data) => {
+    const { password, confirmPassword } = data;
+    try {
+      if (password !== confirmPassword) {
+        throw new Error("Passwords do not match");
+      } else if (user?.email) {
+        const credential = EmailAuthProvider.credential(user.email, password);
+        const usercred = await linkWithCredential(user, credential);
+        setSuccessNotificationOpen(true);
+        router.push("/profile");
+      }
+    } catch (error: any) {
+      setErrorMessage(handleErrors(error.message));
+      setErrorNotificationOpen(true);
+    }
+  };
+  return (
+    <>
+      {/* Profile update error snackbar */}
+      <Snackbar
+        variety="error"
+        open={errorNotificationOpen}
+        onClose={() => setErrorNotificationOpen(false)}
+      >
+        Error: {errorMessage}
+      </Snackbar>
+
+      {/* Profile update success snackbar */}
+      <Snackbar
+        variety="success"
+        open={successNotificationOpen}
+        onClose={() => setSuccessNotificationOpen(false)}
+      >
+        Success: Account has been linked to an email and password!
+      </Snackbar>
+
+      <h3 className="mt-0 mb-4 font-normal">Set up a password</h3>
+      <div className="text-sm mb-4">
+        Passwords should meet the following requirements:
+        <ul className="m-0 px-4">
+          <li>At least 6 characters in length</li>
+          <li>Contain a mix of uppercase and lowercase letters</li>
+          <li>Include at least one number and one special character</li>
+        </ul>
+      </div>
+      <form onSubmit={handleSubmit(handleSubmitForm)} className="space-y-4">
+        <div>
+          <TextField
+            error={errors.password?.message}
+            type="password"
+            label="New password"
+            {...register("password", {
+              required: { value: true, message: "Required" },
+              minLength: {
+                value: 6,
+                message: "Password must be at least 6 characters",
+              },
+              validate: {
+                hasUpper: (value) =>
+                  /.*[A-Z].*/.test(value) ||
+                  "Password must contain at least one uppercase letter",
+                hasLower: (value) =>
+                  /.*[a-z].*/.test(value) ||
+                  "Password must contain at least one lowercase letter",
+                hasNumber: (value) =>
+                  /.*[0-9].*/.test(value) ||
+                  "Password must contain at least one number",
+                hasSpecialChar: (value) =>
+                  /.*[\W_].*/.test(value) ||
+                  "Password must contain at least one special character",
+              },
+            })}
+          />
+        </div>
+        <div>
+          <TextField
+            type="password"
+            error={errors.confirmPassword?.message}
+            label="Confirm password"
+            {...register("confirmPassword", {
+              required: { value: true, message: "Required" },
+              validate: {
+                matchPassword: (value) =>
+                  value === watch("password") || "Passwords do not match",
+              },
+            })}
+          />
+        </div>
+        <div>
+          <Button type="submit">Create password</Button>
+        </div>
+      </form>
+    </>
+  );
+};
+export default LinkEmailPasswordForm;

--- a/frontend/src/components/organisms/ManageProvidersForm.tsx
+++ b/frontend/src/components/organisms/ManageProvidersForm.tsx
@@ -1,0 +1,93 @@
+import React, { useState } from "react";
+import { useAuth } from "@/utils/AuthContext";
+import Button from "../atoms/Button";
+import EmailIcon from "@mui/icons-material/Email";
+import IconText from "@/components/atoms/IconText";
+import GoogleIcon from "@mui/icons-material/Google";
+import Snackbar from "../atoms/Snackbar";
+import { unlink } from "firebase/auth";
+
+const ManageProvidersForm = () => {
+  /** State variables for the notification popups */
+  const [successNotificationOpen, setSuccessNotificationOpen] = useState(false);
+  const [errorNotificationOpen, setErrorNotificationOpen] = useState(false);
+
+  /** Error message state */
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const { user } = useAuth();
+  const hasEmailProvider = user?.providerData.some(
+    (x) => x.providerId === "password"
+  );
+  const hasGoogleProvider = user?.providerData.some(
+    (x) => x.providerId === "google.com"
+  );
+
+  /** Unlinks the Google provider from the user account */
+  const handleUnlinkGoogle = async (providerId: string) => {
+    try {
+      if (user) {
+        await unlink(user, providerId);
+        setSuccessNotificationOpen(true);
+      } else {
+        throw new Error("User not found");
+      }
+    } catch (error: any) {
+      setErrorMessage(error.message);
+      setErrorNotificationOpen(true);
+    }
+  };
+  return (
+    <div>
+      {/* Profile update error snackbar */}
+      <Snackbar
+        variety="error"
+        open={errorNotificationOpen}
+        onClose={() => setErrorNotificationOpen(false)}
+      >
+        Error: {errorMessage}
+      </Snackbar>
+
+      {/* Profile update success snackbar */}
+      <Snackbar
+        variety="success"
+        open={successNotificationOpen}
+        onClose={() => setSuccessNotificationOpen(false)}
+      >
+        Success: Account has been unlinked!
+      </Snackbar>
+
+      <h3 className="mt-0 mb-4 font-normal">My authentication providers</h3>
+      {hasEmailProvider && (
+        <div className="border-gray-400 border border-solid flex px-3 h-14 items-center rounded-xl">
+          <IconText icon={<EmailIcon />}>Email and password</IconText>
+        </div>
+      )}
+      {hasGoogleProvider && (
+        <div className="border-gray-400 border border-solid flex px-3 h-14 items-center rounded-xl mt-2">
+          <div className="flex items-center justify-between w-full">
+            <IconText icon={<GoogleIcon />}>Google</IconText>
+            <div>
+              {hasEmailProvider ? (
+                <Button
+                  size="small"
+                  variety="error"
+                  fullWidth={false}
+                  onClick={() => handleUnlinkGoogle("google.com")}
+                >
+                  Unlink account
+                </Button>
+              ) : (
+                <Button size="small" variety="error" fullWidth={false} disabled>
+                  Unlink account
+                </Button>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ManageProvidersForm;

--- a/frontend/src/pages/profile.tsx
+++ b/frontend/src/pages/profile.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import ProfileForm from "@/components/organisms/ProfileForm";
 import ChangePasswordForm from "@/components/organisms/ChangePasswordForm";
 import CenteredTemplate from "@/components/templates/CenteredTemplate";
-import Banner from "@/components/molecules/Banner";
 import { useAuth } from "@/utils/AuthContext";
 import Avatar from "@/components/molecules/Avatar";
 import Card from "@/components/molecules/Card";
@@ -12,6 +11,8 @@ import Loading from "@/components/molecules/Loading";
 import FetchDataError from "@/components/organisms/FetchDataError";
 import { formatRoleOrStatus } from "@/utils/helpers";
 import DefaultTemplate from "@/components/templates/DefaultTemplate";
+import LinkEmailPasswordForm from "@/components/organisms/LinkEmailPasswordForm";
+import ManageProvidersForm from "@/components/organisms/ManageProvidersForm";
 
 /** A Profile page */
 const Profile = () => {
@@ -43,6 +44,11 @@ const Profile = () => {
       </DefaultTemplate>
     );
   }
+
+  /** Whether the user only has sign-in providers */
+  const hasOnlyGoogleProvider =
+    user?.providerData.some((x) => x.providerId === "google.com") &&
+    !user?.providerData.some((x) => x.providerId === "password");
 
   return (
     <CenteredTemplate>
@@ -109,13 +115,20 @@ const Profile = () => {
         />
       </Card>
       <h3 className="text-xl font-normal mt-12">My Account</h3>
+      <Card size="medium" className="mb-4">
+        <ManageProvidersForm />
+      </Card>
       <Card size="medium">
-        <ChangePasswordForm
-          userDetails={{
-            ...data.profile,
-            ...data,
-          }}
-        />
+        {hasOnlyGoogleProvider ? (
+          <LinkEmailPasswordForm />
+        ) : (
+          <ChangePasswordForm
+            userDetails={{
+              ...data.profile,
+              ...data,
+            }}
+          />
+        )}
       </Card>
     </CenteredTemplate>
   );


### PR DESCRIPTION
## Summary

Users can now see whether they're logged in with Google vs email/password. If logged in with Google, they can create a new password. They can also choose to unlink their Google auth provider (only if they also have email/password enabled). You can no longer "change your password" if you don't have a password set.

## Testing

See screenshots:
![image](https://github.com/cornellh4i/lagos-volunteers/assets/48730262/3c685cf3-b6a3-48f1-b32b-f897b5e20156)
![image](https://github.com/cornellh4i/lagos-volunteers/assets/48730262/a6134643-96a7-4f2c-8792-4537011cd027)


## Notes

User can still reset their password if they don't have a previous password set. This behavior is consistent with other apps (tested with Asana).