### PR TITLE
Implement volunteer cancel event flow

### DIFF
--- a/backend/src/events/controllers.ts
+++ b/backend/src/events/controllers.ts
@@ -463,7 +463,7 @@ const deleteAttendee = async (
       },
     },
     data: {
-      canceled: true,
+      attendeeStatus: "CANCELED",
       cancelationMessage: cancelationMessage,
     },
   });

--- a/backend/src/events/controllers.ts
+++ b/backend/src/events/controllers.ts
@@ -340,7 +340,7 @@ const updateEnrollmentStatus = async (
   userID: string,
   newStatus: EnrollmentStatus
 ) => {
-  const res = await prisma.eventEnrollment.update({
+  return await prisma.eventEnrollment.update({
     where: {
       userId_eventId: {
         userId: userID,
@@ -351,8 +351,6 @@ const updateEnrollmentStatus = async (
       attendeeStatus: newStatus,
     },
   });
-  console.log(res);
-  return res;
 };
 
 /**

--- a/backend/src/events/views.ts
+++ b/backend/src/events/views.ts
@@ -170,15 +170,15 @@ eventRouter.patch(
 );
 
 eventRouter.put(
-  "/:eventid/attendees",
-  useAdminAuth || useSupervisorAuth,
+  "/:eventid/attendees/:attendeeid/cancel",
+  useAuth,
   async (req: Request, res: Response) => {
     // #swagger.tags = ['Events']
-    const { attendeeid, cancelationMessage } = req.body;
+    const { cancelationMessage } = req.body;
     attempt(res, 200, () =>
       eventController.deleteAttendee(
         req.params.eventid,
-        attendeeid,
+        req.params.attendeeid,
         cancelationMessage
       )
     );

--- a/frontend/src/components/organisms/EventCardCancel.tsx
+++ b/frontend/src/components/organisms/EventCardCancel.tsx
@@ -154,14 +154,14 @@ const EventCardCancel = ({
         {hoursLeftToCancel < 0 ? (
           <div>
             You have passed the window for canceling your registration.
-            Registration must be cancelled at least 24 hours before the event
+            Registration must be canceled at least 24 hours before the event
             begins. Failure to do so may affect your volunteer status.
           </div>
         ) : (
           <div>
             <div>
               If you can no longer attend, please cancel your registration.
-              Registration must be cancelled at least 24 hours before the event
+              Registration must be canceled at least 24 hours before the event
               begins. Failure to do so may affect your volunteer status.
             </div>
             <div className="mt-3" />

--- a/frontend/src/components/organisms/EventCardCancel.tsx
+++ b/frontend/src/components/organisms/EventCardCancel.tsx
@@ -14,6 +14,7 @@ import { useForm, SubmitHandler } from "react-hook-form";
 interface EventCardCancelProps {
   attendeeId: string;
   eventId: string;
+  attendeeStatus: string;
   date: Date;
 }
 
@@ -62,6 +63,7 @@ const ModalBody = ({ handleClose, mutateFn }: modalProps) => {
 const EventCardCancel = ({
   eventId,
   attendeeId,
+  attendeeStatus,
   date,
 }: EventCardCancelProps) => {
   const { user } = useAuth();
@@ -96,7 +98,7 @@ const EventCardCancel = ({
   } = useMutation({
     mutationKey: ["event", eventId],
     mutationFn: async () => {
-      await api.put(`/events/${eventId}/attendees`, {
+      await api.put(`/events/${eventId}/attendees/${attendeeId}/cancel`, {
         attendeeid: attendeeId,
         cancelationMessage: cancelationMessage,
       });
@@ -117,7 +119,11 @@ const EventCardCancel = ({
 
   /** Register button should be disabled if event is in the past */
   const currentDate = new Date();
-  const disableCancelEvent = date < currentDate;
+
+  // We assume the deadline to cancel is 24 hours in advance.
+  const millisecondsPerHour = 1000 * 60 * 60;
+  const hoursLeftToCancel =
+    (date.getTime() - currentDate.getTime()) / millisecondsPerHour - 24;
 
   return (
     <>
@@ -130,41 +136,53 @@ const EventCardCancel = ({
       <Card>
         <div className="font-semibold text-2xl">You're registered</div>
         <div className="mt-5" />
+        <div className="mb-2">
+          Your registration status is <b>{attendeeStatus}</b>.
+        </div>
+        <div className="mt-5" />
         <div className="font-semibold text-lg mb-2">
           No longer able to attend?
         </div>
-        <IconText icon={<AccessTimeFilledIcon />}>
-          {/* TODO: Update how many hours left */}
-          <div>4 hours left to cancel registration</div>
-        </IconText>
+        {hoursLeftToCancel > 0 && (
+          <IconText icon={<AccessTimeFilledIcon />}>
+            <div>
+              {Math.round(hoursLeftToCancel)} hours left to cancel registration
+            </div>
+          </IconText>
+        )}
         <div className="mt-3" />
-        <div>
-          If you can no longer attend, please cancel your registration.
-          Registration must be cancelled at least 24 hours before the event
-          begins. Failure to do so may affect your volunteer status.
-        </div>
-        <div className="mt-3" />
-        <form onSubmit={handleSubmit(handleCancelSubmissionReason)}>
-          <div className="font-semibold text-lg">Reason for canceling</div>
-          <MultilineTextField
-            error={errors.cancelReason?.message}
-            placeholder="Your answer here"
-            value={cancelationMessage}
-            {...register("cancelReason", {
-              required: { value: true, message: "Required" },
-            })}
-            disabled={disableCancelEvent}
-            onChange={(e: any) => setCancelationMessage(e.target.value)}
-          />
-          <div className="mt-3" />
-          {disableCancelEvent ? (
-            <Button disabled>The event has concluded.</Button>
-          ) : (
-            <Button type="submit" variety="error">
-              Cancel registration
-            </Button>
-          )}
-        </form>
+        {hoursLeftToCancel < 0 ? (
+          <div>
+            You have passed the window for canceling your registration.
+            Registration must be cancelled at least 24 hours before the event
+            begins. Failure to do so may affect your volunteer status.
+          </div>
+        ) : (
+          <div>
+            <div>
+              If you can no longer attend, please cancel your registration.
+              Registration must be cancelled at least 24 hours before the event
+              begins. Failure to do so may affect your volunteer status.
+            </div>
+            <div className="mt-3" />
+            <form onSubmit={handleSubmit(handleCancelSubmissionReason)}>
+              <div className="font-semibold text-lg">Reason for canceling</div>
+              <MultilineTextField
+                error={errors.cancelReason?.message}
+                placeholder="Your answer here"
+                value={cancelationMessage}
+                {...register("cancelReason", {
+                  required: { value: true, message: "Required" },
+                })}
+                onChange={(e: any) => setCancelationMessage(e.target.value)}
+              />
+              <div className="mt-3" />
+              <Button type="submit" variety="mainError">
+                Cancel registration
+              </Button>
+            </form>
+          </div>
+        )}
       </Card>
     </>
   );

--- a/frontend/src/components/organisms/EventCardCancel.tsx
+++ b/frontend/src/components/organisms/EventCardCancel.tsx
@@ -32,8 +32,7 @@ const ModalBody = ({ handleClose, mutateFn }: modalProps) => {
           display: "flex",
           justifyContent: "center",
           alignItems: "center",
-        }}
-      >
+        }}>
         <h2 className="mt-0">Cancel Registration</h2>
       </Box>
       <Box
@@ -42,8 +41,7 @@ const ModalBody = ({ handleClose, mutateFn }: modalProps) => {
           display: "flex",
           justifyContent: "center",
           alignItems: "center",
-        }}
-      >
+        }}>
         <div>Are you sure you want to cancel?</div>
       </Box>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
@@ -122,8 +120,9 @@ const EventCardCancel = ({
 
   // We assume the deadline to cancel is 24 hours in advance.
   const millisecondsPerHour = 1000 * 60 * 60;
-  const hoursLeftToCancel =
-    (date.getTime() - currentDate.getTime()) / millisecondsPerHour - 24;
+  const hoursLeftToCancel = Math.round(
+    (date.getTime() - currentDate.getTime()) / millisecondsPerHour - 24
+  );
 
   return (
     <>
@@ -145,9 +144,13 @@ const EventCardCancel = ({
         </div>
         {hoursLeftToCancel > 0 && (
           <IconText icon={<AccessTimeFilledIcon />}>
-            <div>
-              {Math.round(hoursLeftToCancel)} hours left to cancel registration
-            </div>
+            {hoursLeftToCancel < 48 ? (
+              <div>{hoursLeftToCancel}hours left to cancel registration</div>
+            ) : (
+              <div>
+                {Math.round(hoursLeftToCancel / 24)} days left to cancel
+              </div>
+            )}
           </IconText>
         )}
         <div className="mt-3" />

--- a/frontend/src/components/organisms/ViewEventDetails.tsx
+++ b/frontend/src/components/organisms/ViewEventDetails.tsx
@@ -12,7 +12,10 @@ import { useRouter } from "next/router";
 import { useAuth } from "@/utils/AuthContext";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/utils/api";
-import { fetchUserIdFromDatabase } from "@/utils/helpers";
+import {
+  convertEnrollmentStatusToString,
+  fetchUserIdFromDatabase,
+} from "@/utils/helpers";
 import { formatDateTimeRange } from "@/utils/helpers";
 import { EventData } from "@/utils/types";
 import Loading from "@/components/molecules/Loading";
@@ -50,7 +53,7 @@ const ViewEventDetails = () => {
 
   /** If the user canceled their event registration */
   const userHasCanceledAttendance =
-    eventAttendance && eventAttendance["canceled"];
+    eventAttendance && eventAttendance.attendeeStatus === "CANCELED";
 
   /** Set event details */
   const {
@@ -135,6 +138,9 @@ const ViewEventDetails = () => {
             ) : eventAttendance ? (
               <EventCardCancel
                 eventId={eventid}
+                attendeeStatus={convertEnrollmentStatusToString(
+                  eventAttendance.attendeeStatus
+                )}
                 attendeeId={userid}
                 date={new Date(eventData.startDate)}
               />

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -228,5 +228,7 @@ export const convertEnrollmentStatusToString = (status: string) => {
       return "Removed";
     case "CANCELED":
       return "Canceled";
+    default:
+      return "";
   }
 };


### PR DESCRIPTION
## Summary

Fixes the following:
- Correctly show that an event is canceled on the ViewEventDetails page.
- BUG: Attempting to cancel registration for a registered event returns an Unauthorized PUT request for volunteers. (likely because of backend API protection preventing volunteers)
- Update how many hours left on cancel event card.
- Volunteers should see their checked in status for upcoming events (see in ViewEventDetails)

## Testing

![image](https://github.com/cornellh4i/lagos-volunteers/assets/48730262/087f7b42-c657-4650-80b5-447bbb4b96de)

## Notes

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->