### PR TITLE
Implement signup cap in ManageAttendees and ViewEventDetails

### DIFF
--- a/backend/src/events/controllers.ts
+++ b/backend/src/events/controllers.ts
@@ -344,7 +344,7 @@ const getAttendee = async (eventID: string, userID: string) => {
  * volunteers are registered for the event. Note: volunteers are not considered
  * registered if they have canceled their registration or if their registration
  * has been removed by the supervisor.
- * @param attendees - The list of EventEnrollment objects
+ * @param eventid - The event id
  * @returns The number of registered volunteers
  */
 export const getRegisteredVolunteerNumberInEvent = async (eventid: string) => {

--- a/backend/src/events/controllers.ts
+++ b/backend/src/events/controllers.ts
@@ -279,6 +279,7 @@ const getEvent = async (eventID: string) => {
       id: eventID,
     },
     include: {
+      attendees: true,
       owner: {
         select: {
           profile: true,

--- a/backend/src/events/views.ts
+++ b/backend/src/events/views.ts
@@ -127,14 +127,31 @@ eventRouter.get("/:eventid", useAuth, async (req: Request, res: Response) => {
 
 eventRouter.get(
   "/:eventid/attendees",
-  useAdminAuth || useSupervisorAuth,
+  useAuth,
+  async (req: Request, res: Response) => {
+    // #swagger.tags = ['Events']
+    attempt(res, 200, () => eventController.getAttendees(req.params.eventid));
+  }
+);
+
+eventRouter.get(
+  "/:eventid/attendees/:userid",
+  useAuth,
   async (req: Request, res: Response) => {
     // #swagger.tags = ['Events']
     attempt(res, 200, () =>
-      eventController.getAttendees(
-        req.params.eventid,
-        req.query.userid as string
-      )
+      eventController.getAttendee(req.params.eventid, req.params.userid)
+    );
+  }
+);
+
+eventRouter.get(
+  "/:eventid/attendees/registered/length",
+  useAuth,
+  async (req: Request, res: Response) => {
+    // #swagger.tags = ['Events']
+    attempt(res, 200, () =>
+      eventController.getRegisteredVolunteerNumberInEvent(req.params.eventid)
     );
   }
 );

--- a/frontend/src/components/organisms/EventCardCancel.tsx
+++ b/frontend/src/components/organisms/EventCardCancel.tsx
@@ -149,9 +149,9 @@ const EventCardCancel = ({
         <div className="mt-3" />
         {hoursLeftToCancel < 0 ? (
           <div>
-            have passed the window for canceling your registration. Registration
-            must be canceled at least 24 hours before the event begins. Failure
-            to do so may affect your volunteer status.
+            You have passed the window for canceling your registration.
+            Registration must be canceled at least 24 hours before the event
+            begins. Failure to do so may affect your volunteer status.
           </div>
         ) : attendeeStatus !== "PENDING" ? (
           <div>

--- a/frontend/src/components/organisms/EventCardCancel.tsx
+++ b/frontend/src/components/organisms/EventCardCancel.tsx
@@ -10,6 +10,7 @@ import { useAuth } from "@/utils/AuthContext";
 import { Box, Grid } from "@mui/material";
 import Modal from "@/components/molecules/Modal";
 import { useForm, SubmitHandler } from "react-hook-form";
+import { convertEnrollmentStatusToString } from "@/utils/helpers";
 
 interface EventCardCancelProps {
   attendeeId: string;
@@ -32,7 +33,8 @@ const ModalBody = ({ handleClose, mutateFn }: modalProps) => {
           display: "flex",
           justifyContent: "center",
           alignItems: "center",
-        }}>
+        }}
+      >
         <h2 className="mt-0">Cancel Registration</h2>
       </Box>
       <Box
@@ -41,7 +43,8 @@ const ModalBody = ({ handleClose, mutateFn }: modalProps) => {
           display: "flex",
           justifyContent: "center",
           alignItems: "center",
-        }}>
+        }}
+      >
         <div>Are you sure you want to cancel?</div>
       </Box>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
@@ -136,32 +139,40 @@ const EventCardCancel = ({
         <div className="font-semibold text-2xl">You're registered</div>
         <div className="mt-5" />
         <div className="mb-2">
-          Your registration status is <b>{attendeeStatus}</b>.
+          Your registration status is{" "}
+          <b>{convertEnrollmentStatusToString(attendeeStatus)}</b>.
         </div>
         <div className="mt-5" />
         <div className="font-semibold text-lg mb-2">
           No longer able to attend?
         </div>
-        {hoursLeftToCancel > 0 && (
-          <IconText icon={<AccessTimeFilledIcon />}>
-            {hoursLeftToCancel < 48 ? (
-              <div>{hoursLeftToCancel}hours left to cancel registration</div>
-            ) : (
-              <div>
-                {Math.round(hoursLeftToCancel / 24)} days left to cancel
-              </div>
-            )}
-          </IconText>
-        )}
         <div className="mt-3" />
         {hoursLeftToCancel < 0 ? (
           <div>
-            You have passed the window for canceling your registration.
-            Registration must be canceled at least 24 hours before the event
-            begins. Failure to do so may affect your volunteer status.
+            have passed the window for canceling your registration. Registration
+            must be canceled at least 24 hours before the event begins. Failure
+            to do so may affect your volunteer status.
+          </div>
+        ) : attendeeStatus !== "PENDING" ? (
+          <div>
+            Your attendee status has been modified by a supervisor. You are no
+            longer able to cancel your registration.
           </div>
         ) : (
           <div>
+            <div className="mb-2">
+              <IconText icon={<AccessTimeFilledIcon />}>
+                {hoursLeftToCancel < 48 ? (
+                  <div>
+                    {hoursLeftToCancel} hours left to cancel registration
+                  </div>
+                ) : (
+                  <div>
+                    {Math.round(hoursLeftToCancel / 24)} days left to cancel
+                  </div>
+                )}
+              </IconText>
+            </div>
             <div>
               If you can no longer attend, please cancel your registration.
               Registration must be canceled at least 24 hours before the event

--- a/frontend/src/components/organisms/EventCardRegister.tsx
+++ b/frontend/src/components/organisms/EventCardRegister.tsx
@@ -8,13 +8,15 @@ import { useAuth } from "@/utils/AuthContext";
 import Alert from "../atoms/Alert";
 
 interface EventRegisterCardProps {
-  attendeeId: string;
   eventId: string;
+  overCapacity: boolean;
+  attendeeId: string;
   date: Date;
 }
 
 const EventCardRegister = ({
   eventId,
+  overCapacity,
   attendeeId,
   date,
 }: EventRegisterCardProps) => {
@@ -58,12 +60,14 @@ const EventCardRegister = ({
       <div className="mt-3" />
       <CustomCheckbox
         label="I agree to the terms and conditions"
-        disabled={disableRegisterEvent}
+        disabled={disableRegisterEvent || overCapacity}
         onChange={() => setIsChecked(!isChecked)}
       />
       <div className="mt-3" />
       {disableRegisterEvent ? (
         <Button disabled>The event has concluded.</Button>
+      ) : overCapacity ? (
+        <Button disabled>The event has reached capacity.</Button>
       ) : (
         <Button
           onClick={handleEventResgistration}

--- a/frontend/src/components/organisms/EventCardRegister.tsx
+++ b/frontend/src/components/organisms/EventCardRegister.tsx
@@ -5,7 +5,6 @@ import Button from "../atoms/Button";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/utils/api";
 import { useAuth } from "@/utils/AuthContext";
-import Alert from "../atoms/Alert";
 
 interface EventRegisterCardProps {
   eventId: string;

--- a/frontend/src/components/organisms/ManageAttendees.tsx
+++ b/frontend/src/components/organisms/ManageAttendees.tsx
@@ -23,7 +23,11 @@ import DatePicker from "../atoms/DatePicker";
 import TimePicker from "../atoms/TimePicker";
 import Snackbar from "../atoms/Snackbar";
 import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
-import { convertToISO, fetchUserIdFromDatabase } from "@/utils/helpers";
+import {
+  convertToISO,
+  fetchUserIdFromDatabase,
+  registeredVolunteerNumberInEvent,
+} from "@/utils/helpers";
 import { useAuth } from "@/utils/AuthContext";
 import router from "next/router";
 import { api } from "@/utils/api";
@@ -668,7 +672,12 @@ const ManageAttendees = () => {
           />
           <IconTextHeader
             icon={<GroupsIcon />}
-            header={<>{capacity} volunteers needed</>}
+            header={
+              <>
+                {registeredVolunteerNumberInEvent(eventData.attendees)}/
+                {capacity} volunteers registered
+              </>
+            }
           />
           <TextCopy
             label="RSVP Link"

--- a/frontend/src/components/organisms/ManageAttendees.tsx
+++ b/frontend/src/components/organisms/ManageAttendees.tsx
@@ -1,10 +1,4 @@
-import React, {
-  ChangeEvent,
-  FormEvent,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+import React, { ChangeEvent, FormEvent, useState } from "react";
 import TabContainer from "@/components/molecules/TabContainer";
 import {
   GridColDef,

--- a/frontend/src/components/organisms/ManageAttendees.tsx
+++ b/frontend/src/components/organisms/ManageAttendees.tsx
@@ -119,8 +119,8 @@ const AttendeesTable = ({
     },
     retry: false,
     onSuccess: () => {
-      // Invalidate the Event Recap query to fetch new data
-      queryClient.invalidateQueries({ queryKey: ["event"] });
+      // Invalidate the number of registered volunteers query to fetch new data
+      queryClient.invalidateQueries({ queryKey: ["registeredVoluneers"] });
 
       // Invalidate the Manage Attendees query to fetch new data
       queryClient.invalidateQueries({ queryKey: [eventid] });
@@ -625,6 +625,17 @@ const ManageAttendees = () => {
 
   /** Loading screen */
 
+  /** Number of registered volunteers */
+  const { data: registeredVolunteersNumber } = useQuery({
+    queryKey: ["registeredVoluneers", eventid],
+    queryFn: async () => {
+      const { data } = await api.get(
+        `/events/${eventid}/attendees/registered/length`
+      );
+      return data.data;
+    },
+  });
+
   return (
     <>
       {/* Notifications */}
@@ -683,8 +694,7 @@ const ManageAttendees = () => {
             icon={<GroupsIcon />}
             header={
               <>
-                {registeredVolunteerNumberInEvent(eventData.attendees)}/
-                {capacity} volunteers registered
+                {registeredVolunteersNumber}/{capacity} volunteers registered
               </>
             }
           />

--- a/frontend/src/components/organisms/ManageAttendees.tsx
+++ b/frontend/src/components/organisms/ManageAttendees.tsx
@@ -23,11 +23,7 @@ import DatePicker from "../atoms/DatePicker";
 import TimePicker from "../atoms/TimePicker";
 import Snackbar from "../atoms/Snackbar";
 import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
-import {
-  convertToISO,
-  fetchUserIdFromDatabase,
-  registeredVolunteerNumberInEvent,
-} from "@/utils/helpers";
+import { convertToISO, fetchUserIdFromDatabase } from "@/utils/helpers";
 import { useAuth } from "@/utils/AuthContext";
 import router from "next/router";
 import { api } from "@/utils/api";

--- a/frontend/src/components/organisms/ManageAttendees.tsx
+++ b/frontend/src/components/organisms/ManageAttendees.tsx
@@ -119,6 +119,10 @@ const AttendeesTable = ({
     },
     retry: false,
     onSuccess: () => {
+      // Invalidate the Event Recap query to fetch new data
+      queryClient.invalidateQueries({ queryKey: ["event"] });
+
+      // Invalidate the Manage Attendees query to fetch new data
       queryClient.invalidateQueries({ queryKey: [eventid] });
 
       // Invalidating the cache will fetch new data from the server
@@ -133,6 +137,10 @@ const AttendeesTable = ({
     lastMessage.data ==
       `{"resource":"/events/${eventid}","message":"The resource has been updated!"}`
   ) {
+    // Invalidate the Event Recap query to fetch new data
+    queryClient.invalidateQueries({ queryKey: ["event"] });
+
+    // Invalidate the Manage Attendees query to fetch new data
     queryClient.invalidateQueries({ queryKey: [eventid] });
   }
 
@@ -468,6 +476,7 @@ const ManageAttendees = () => {
   const { user, role } = useAuth();
   const [userid, setUserid] = React.useState("");
 
+  /** Tanstack query for fetching event information to show in the Event Recap */
   const { data, isLoading, isError, error } = useQuery({
     queryKey: ["event", eventid],
     queryFn: async () => {

--- a/frontend/src/components/organisms/ViewEventDetails.tsx
+++ b/frontend/src/components/organisms/ViewEventDetails.tsx
@@ -15,7 +15,6 @@ import { api } from "@/utils/api";
 import {
   convertEnrollmentStatusToString,
   fetchUserIdFromDatabase,
-  registeredVolunteerNumberInEvent,
 } from "@/utils/helpers";
 import { formatDateTimeRange } from "@/utils/helpers";
 import { EventData } from "@/utils/types";

--- a/frontend/src/components/organisms/ViewEventDetails.tsx
+++ b/frontend/src/components/organisms/ViewEventDetails.tsx
@@ -15,6 +15,7 @@ import { api } from "@/utils/api";
 import {
   convertEnrollmentStatusToString,
   fetchUserIdFromDatabase,
+  registeredVolunteerNumberInEvent,
 } from "@/utils/helpers";
 import { formatDateTimeRange } from "@/utils/helpers";
 import { EventData } from "@/utils/types";
@@ -41,15 +42,16 @@ const ViewEventDetails = () => {
     queryFn: async () => {
       const userid = await fetchUserIdFromDatabase(user?.email as string);
       setUserid(userid);
-      const { data } = await api.get(
-        `/users/${userid}/registered?eventid=${id}`
-      );
+      const { data } = await api.get(`/events/${id}`);
       return data["data"];
     },
   });
 
-  let eventData = data?.eventDetails || {};
-  let eventAttendance = data?.attendance;
+  /** Undefined if user not in the attendees list, otherwise EventAttendance object */
+  let eventData = data || {};
+  let eventAttendance = eventData?.attendees?.find(
+    (attendee: any) => attendee.userId === userid
+  );
 
   /** If the user canceled their event registration */
   const userHasCanceledAttendance =
@@ -111,7 +113,12 @@ const ViewEventDetails = () => {
             />
             <IconTextHeader
               icon={<GroupsIcon />}
-              header={<>{capacity} volunteers needed</>}
+              header={
+                <>
+                  {registeredVolunteerNumberInEvent(eventData.attendees)}/
+                  {capacity} volunteers registered
+                </>
+              }
             />
           </div>
         </div>

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -233,3 +233,19 @@ export const convertEnrollmentStatusToString = (status: string) => {
       return "";
   }
 };
+
+/**
+ * Given a list of EventEnrollment objects from the database, returns how many
+ * volunteers are registered for the event. Note: volunteers are not considered
+ * registered if they have canceled their registration or if their registration
+ * has been removed by the supervisor.
+ * @param attendees - The list of EventEnrollment objects
+ * @returns The number of registered volunteers
+ */
+export const registeredVolunteerNumberInEvent = (attendees?: any[]) => {
+  return attendees?.filter(
+    (attendee: any) =>
+      attendee.attendeeStatus !== "CANCELED" &&
+      attendee.attendeeStatus !== "REMOVED"
+  ).length;
+};

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -233,19 +233,3 @@ export const convertEnrollmentStatusToString = (status: string) => {
       return "";
   }
 };
-
-/**
- * Given a list of EventEnrollment objects from the database, returns how many
- * volunteers are registered for the event. Note: volunteers are not considered
- * registered if they have canceled their registration or if their registration
- * has been removed by the supervisor.
- * @param attendees - The list of EventEnrollment objects
- * @returns The number of registered volunteers
- */
-export const registeredVolunteerNumberInEvent = (attendees?: any[]) => {
-  return attendees?.filter(
-    (attendee: any) =>
-      attendee.attendeeStatus !== "CANCELED" &&
-      attendee.attendeeStatus !== "REMOVED"
-  ).length;
-};


### PR DESCRIPTION
## Summary

Show the volunteer signup cap properly and prevent volunteers from signing up when exceeding the limit. Also implement WebSockets so that the number of registered volunteers automatically refreshes when the user cancels their registration or is canceled by the supervisor. Finally, volunteers can no longer cancel if the supervisor moves them away from PENDING.

Closes:
- Prevent volunteers from signing up if the volunteer signup cap is already reached

## Testing

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->
![image](https://github.com/cornellh4i/lagos-volunteers/assets/48730262/0de7aa8e-b21f-4389-8ac3-1eb7e95cec1b)
![image](https://github.com/cornellh4i/lagos-volunteers/assets/48730262/e9edd300-6308-4ff0-8c0a-a9e9e2ed8992)


## Notes

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->