### PR TITLE
Display cancelation message in ManageAttendees

### DIFF
--- a/backend/src/events/controllers.ts
+++ b/backend/src/events/controllers.ts
@@ -279,7 +279,6 @@ const getEvent = async (eventID: string) => {
       id: eventID,
     },
     include: {
-      attendees: true,
       owner: {
         select: {
           profile: true,

--- a/backend/src/events/controllers.ts
+++ b/backend/src/events/controllers.ts
@@ -279,6 +279,7 @@ const getEvent = async (eventID: string) => {
       id: eventID,
     },
     include: {
+      attendees: true,
       owner: {
         select: {
           profile: true,

--- a/frontend/src/components/organisms/ManageAttendees.tsx
+++ b/frontend/src/components/organisms/ManageAttendees.tsx
@@ -89,7 +89,7 @@ const ViewCancelMessageModalBody = ({
         Reason for Cancelation
       </div>
       <MultilineTextField disabled value={eventAttendance.cancelationMessage} />
-      <Button onClick={handleClose}>Cancel</Button>
+      <Button onClick={handleClose}>Close</Button>
     </div>
   );
 };

--- a/frontend/src/components/organisms/ManageAttendees.tsx
+++ b/frontend/src/components/organisms/ManageAttendees.tsx
@@ -70,16 +70,16 @@ type FormValues = {
 
 interface ViewCancelMessageModalBodyProps {
   handleClose: () => void;
-  eventData?: any;
+  attendees?: any[];
   userid?: string;
 }
 
 const ViewCancelMessageModalBody = ({
   handleClose,
-  eventData,
+  attendees,
   userid,
 }: ViewCancelMessageModalBodyProps) => {
-  const eventAttendance = eventData?.attendees?.find(
+  const eventAttendance = attendees?.find(
     (attendee: any) => attendee.userId === userid
   );
 
@@ -312,6 +312,16 @@ const AttendeesTable = ({
     handleSearchQuery("");
   };
 
+  // Get attendees for event
+  const { data: attendees } = useQuery({
+    queryKey: ["attendees", eventid],
+    queryFn: async () => {
+      const { data } = await api.get(`/events/${eventid}/attendees`);
+      console.log(data.data);
+      return data.data;
+    },
+  });
+
   return (
     <div>
       {/* INFO MESSAGES */}
@@ -353,8 +363,7 @@ const AttendeesTable = ({
         handleClose={handleClose}
         children={
           <ViewCancelMessageModalBody
-            // eventid={eventidCancel}
-            eventData={eventData}
+            attendees={attendees}
             userid={useridCancel}
             handleClose={handleClose}
           />


### PR DESCRIPTION
## Summary

Cancelation messages show up now in a modal according to the hi-fis.

Closes:
- [BUG] Add volunteer cancellation messages to ManageAttendees

## Testing

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->
![image](https://github.com/cornellh4i/lagos-volunteers/assets/48730262/54c9ba6c-f30f-4cd1-ab36-1357a3e4a432)


## Notes

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->