### PR TITLE
feat: Add cancel button to search bar for resetting search query

### DIFF
--- a/frontend/src/components/atoms/SearchBar.tsx
+++ b/frontend/src/components/atoms/SearchBar.tsx
@@ -1,7 +1,7 @@
 import React, { ChangeEvent, FormEvent } from "react";
 import { Box, TextField, InputAdornment, IconButton } from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
-import CancelIcon from "@mui/icons-material/Cancel";
+import ClearIcon from "@mui/icons-material/Clear";
 
 interface SearchBarProps {
   onSubmit: any;
@@ -38,7 +38,7 @@ const SearchBar = ({ onSubmit, ...props }: SearchBarProps) => {
                     props.resetSearch();
                   }}
                 >
-                  <CancelIcon />
+                  <ClearIcon />
                 </IconButton>
               )}
             </InputAdornment>

--- a/frontend/src/components/atoms/SearchBar.tsx
+++ b/frontend/src/components/atoms/SearchBar.tsx
@@ -36,7 +36,8 @@ const SearchBar = ({ onSubmit, ...props }: SearchBarProps) => {
                   edge="end"
                   onClick={() => {
                     props.resetSearch();
-                  }}>
+                  }}
+                >
                   <CancelIcon />
                 </IconButton>
               )}

--- a/frontend/src/components/atoms/SearchBar.tsx
+++ b/frontend/src/components/atoms/SearchBar.tsx
@@ -26,21 +26,24 @@ const SearchBar = ({ onSubmit, ...props }: SearchBarProps) => {
         InputProps={{
           endAdornment: (
             <InputAdornment position="end">
+              {props.showCancelButton && (
+                <div className="flex flex-row items-center">
+                  <IconButton
+                    type="button"
+                    aria-label="cancel"
+                    edge="end"
+                    onClick={() => {
+                      props.resetSearch();
+                    }}
+                  >
+                    <ClearIcon />
+                  </IconButton>
+                  <div className="ml-3 text-gray-400">|</div>
+                </div>
+              )}
               <IconButton type="submit" aria-label="search" edge="end">
                 <SearchIcon />
               </IconButton>
-              {props.showCancelButton && (
-                <IconButton
-                  type="button"
-                  aria-label="cancel"
-                  edge="end"
-                  onClick={() => {
-                    props.resetSearch();
-                  }}
-                >
-                  <ClearIcon />
-                </IconButton>
-              )}
             </InputAdornment>
           ),
         }}

--- a/frontend/src/components/atoms/SearchBar.tsx
+++ b/frontend/src/components/atoms/SearchBar.tsx
@@ -1,6 +1,7 @@
 import React, { ChangeEvent, FormEvent } from "react";
 import { Box, TextField, InputAdornment, IconButton } from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
+import CancelIcon from "@mui/icons-material/Cancel";
 
 interface SearchBarProps {
   onSubmit: any;
@@ -28,6 +29,17 @@ const SearchBar = ({ onSubmit, ...props }: SearchBarProps) => {
               <IconButton type="submit" aria-label="search" edge="end">
                 <SearchIcon />
               </IconButton>
+              {props.showCancelButton && (
+                <IconButton
+                  type="button"
+                  aria-label="cancel"
+                  edge="end"
+                  onClick={() => {
+                    props.resetSearch();
+                  }}>
+                  <CancelIcon />
+                </IconButton>
+              )}
             </InputAdornment>
           ),
         }}

--- a/frontend/src/components/organisms/ManageAttendees.tsx
+++ b/frontend/src/components/organisms/ManageAttendees.tsx
@@ -186,7 +186,8 @@ const AttendeesTable = ({
             value={params.row.status}
             onChange={(event: any) =>
               handleStatusChange(params.row.id, event.target.value)
-            }>
+            }
+          >
             <MenuItem value="PENDING">Pending</MenuItem>
             <MenuItem value="CHECKED_IN">Check in</MenuItem>
             <MenuItem value="CHECKED_OUT">Check out</MenuItem>
@@ -659,7 +660,8 @@ const ManageAttendees = () => {
       <Snackbar
         variety="error"
         open={errorNotificationOpen}
-        onClose={() => setErrorNotificationOpen(false)}>
+        onClose={() => setErrorNotificationOpen(false)}
+      >
         Error: {errorMessage}
       </Snackbar>
 

--- a/frontend/src/components/organisms/ManageAttendees.tsx
+++ b/frontend/src/components/organisms/ManageAttendees.tsx
@@ -186,8 +186,7 @@ const AttendeesTable = ({
             value={params.row.status}
             onChange={(event: any) =>
               handleStatusChange(params.row.id, event.target.value)
-            }
-          >
+            }>
             <MenuItem value="PENDING">Pending</MenuItem>
             <MenuItem value="CHECKED_IN">Check in</MenuItem>
             <MenuItem value="CHECKED_OUT">Check out</MenuItem>
@@ -207,6 +206,11 @@ const AttendeesTable = ({
     event.preventDefault();
     // Set search query
     handleSearchQuery(value);
+  };
+
+  const handleResetSearch = () => {
+    setValue("");
+    handleSearchQuery("");
   };
 
   return (
@@ -248,6 +252,8 @@ const AttendeesTable = ({
           value={value}
           onChange={handleChange}
           onSubmit={handleSubmit}
+          resetSearch={handleResetSearch}
+          showCancelButton={value !== ""}
         />
       </div>
       <Card size="table">
@@ -653,8 +659,7 @@ const ManageAttendees = () => {
       <Snackbar
         variety="error"
         open={errorNotificationOpen}
-        onClose={() => setErrorNotificationOpen(false)}
-      >
+        onClose={() => setErrorNotificationOpen(false)}>
         Error: {errorMessage}
       </Snackbar>
 

--- a/frontend/src/components/organisms/ManageUsers.tsx
+++ b/frontend/src/components/organisms/ManageUsers.tsx
@@ -105,8 +105,7 @@ const Active = ({
         <div>
           <Link
             href={`/users/${params.row.id}/manage`}
-            className="no-underline"
-          >
+            className="no-underline">
             <Button variety="tertiary" size="small" icon={<PersonIcon />}>
               View Profile
             </Button>
@@ -128,6 +127,11 @@ const Active = ({
     handleNewSearchQuery(value);
   };
 
+  const handleResetSearch = () => {
+    setValue("");
+    handleNewSearchQuery("");
+  };
+
   return (
     <div>
       <div className="pb-5 w-full sm:w-[600px]">
@@ -136,6 +140,8 @@ const Active = ({
           value={value}
           onChange={handleChange}
           onSubmit={handleSubmitSearch}
+          resetSearch={handleResetSearch}
+          showCancelButton={value !== ""}
         />
       </div>
       <Card size="table">
@@ -223,8 +229,7 @@ const Blacklisted = ({
         <div>
           <Link
             href={`/users/${params.row.id}/manage`}
-            className="no-underline"
-          >
+            className="no-underline">
             <Button variety="tertiary" size="small" icon={<PersonIcon />}>
               View Profile
             </Button>
@@ -247,6 +252,11 @@ const Blacklisted = ({
     handleNewSearchQuery(value);
   };
 
+  const handleResetSearch = () => {
+    setValue("");
+    handleNewSearchQuery("");
+  };
+
   return (
     <div>
       <div className="pb-5 w-full sm:w-[600px]">
@@ -255,6 +265,8 @@ const Blacklisted = ({
           value={value}
           onChange={handleChange}
           onSubmit={handleSubmitSearch}
+          resetSearch={handleResetSearch}
+          showCancelButton={value !== ""}
         />
       </div>
       <Card size="table">

--- a/frontend/src/components/organisms/ManageUsers.tsx
+++ b/frontend/src/components/organisms/ManageUsers.tsx
@@ -105,7 +105,8 @@ const Active = ({
         <div>
           <Link
             href={`/users/${params.row.id}/manage`}
-            className="no-underline">
+            className="no-underline"
+          >
             <Button variety="tertiary" size="small" icon={<PersonIcon />}>
               View Profile
             </Button>
@@ -229,7 +230,8 @@ const Blacklisted = ({
         <div>
           <Link
             href={`/users/${params.row.id}/manage`}
-            className="no-underline">
+            className="no-underline"
+          >
             <Button variety="tertiary" size="small" icon={<PersonIcon />}>
               View Profile
             </Button>


### PR DESCRIPTION
## Summary

When you start typing a search a cancel button shows up next to the search button if you click it after a search it clears the textbox and fetches fresh data. Like attached screen recording


https://github.com/cornellh4i/lagos-volunteers/assets/59776300/c3108a51-52f1-4570-ac19-33f3603336c7

