### PR TITLE
Fix image handling

### DIFF
--- a/frontend/src/components/atoms/Dropzone.tsx
+++ b/frontend/src/components/atoms/Dropzone.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import Button from "./Button";
 
 interface DropzoneProps {
   setError: React.Dispatch<React.SetStateAction<string>>;
@@ -45,9 +46,29 @@ const Dropzone = ({
       setSelectedFile(file);
     }
   };
+
+  const clearFile = (event: any) => {
+    event.preventDefault();
+    event.target.value = null;
+    setSelectedFile(null);
+  };
+
   return (
     <>
-      <div>{label}</div>
+      <div className="w-full flex">
+        <div className="mt-auto mb-auto">{label}</div>
+        <div className="ml-auto min-w-fit">
+          <Button
+            size="small"
+            fullWidth={false}
+            variety="secondary"
+            onClick={clearFile}
+            disabled={selectedFile ? false : true}
+          >
+            Clear file
+          </Button>
+        </div>
+      </div>
       <div className="flex items-center justify-center w-full">
         <label className="flex flex-col items-center justify-center w-full h-32 border-2 border-gray-300 border-dashed rounded-lg cursor-pointer hover:bg-gray-50">
           <div className="flex flex-col items-center justify-center pt-5 pb-6">

--- a/frontend/src/components/organisms/EventCardNew.tsx
+++ b/frontend/src/components/organisms/EventCardNew.tsx
@@ -112,10 +112,10 @@ const EventCardNew = ({ event }: EventCardNewProps) => {
               <div className="flex-1 hidden md:block md:pl-6">
                 <div className="relative h-full w-full overflow-auto rounded-2xl">
                   <img
-                    className="absolute right-0 h-full rounded-2xl w-[300px] object-cover"
+                    className="absolute right-0 h-full rounded-2xl w-[300px] object-cover border-gray-300 border-solid border"
                     src={
                       event.imageURL == null
-                        ? "/lfbi_sample_event.jpg"
+                        ? "/lfbi_splash.png"
                         : event.imageURL
                     }
                   />

--- a/frontend/src/components/organisms/EventForm.tsx
+++ b/frontend/src/components/organisms/EventForm.tsx
@@ -21,6 +21,7 @@ import {
   convertToISO,
   fetchUserIdFromDatabase,
   uploadImageToFirebase,
+  deleteImageFromFirebase,
 } from "@/utils/helpers";
 import { api } from "@/utils/api";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
@@ -195,8 +196,14 @@ const EventForm = ({
         const userid = await fetchUserIdFromDatabase(user?.email as string);
         const startDateTime = convertToISO(startTime, startDate);
         const endDateTime = convertToISO(endTime, startDate);
-        let newImageURL = imageURL;
+        let newImageURL = imageURL ? imageURL : null;
+
+        // If user uploads a new image, delete the old image before uploading
+        // the new one
         if (selectedFile) {
+          if (eventDetails?.imageURL) {
+            await deleteImageFromFirebase(userid, eventDetails.imageURL);
+          }
           newImageURL = await uploadImageToFirebase(userid, selectedFile); // Update URL if there is any.
         }
 
@@ -507,12 +514,20 @@ const EventForm = ({
             })}
           />
         </div>
+        {eventDetails?.imageURL && (
+          <div>
+            <p>Current image:</p>
+            <img
+              className="w-full rounded-2xl border-gray-300 border-solid border"
+              src={eventDetails.imageURL}
+            />
+          </div>
+        )}
         <Dropzone
           setError={setDropzoneError}
           label="Event Image"
           selectedFile={selectedFile}
           setSelectedFile={setSelectedFile}
-          defaultValue={eventDetails?.imageURL}
         />
 
         {/* <TextCopy

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -6,6 +6,7 @@ import {
   ref,
   uploadBytesResumable,
   getDownloadURL,
+  deleteObject,
 } from "firebase/storage";
 
 /**
@@ -177,6 +178,37 @@ export const displayDateInfo = (date: Date) => {
  */
 export const formatRoleOrStatus = (str: string) => {
   return str[0] + str.substring(1).toLowerCase();
+};
+
+/**
+ * Deletes an image from Firebase
+ * @param userID           - The userID of who uploads the image
+ * @param imageDownloadURL - The image URL
+ * @returns The string URL to the event.
+ */
+export const deleteImageFromFirebase = async (
+  userID: string | null,
+  imageDownloadURL: string
+) => {
+  if (!userID) {
+    console.error("No userID provided");
+    return "";
+  }
+
+  // Extract the path of the image from the download URL
+  const urlParts = imageDownloadURL.split("?")[0]; // Remove the query string
+  const imagePath = decodeURIComponent(urlParts.split("o/")[1]); // Get the file path after 'o/'
+
+  // Get image ref from path
+  const storage = getStorage();
+  const imageRef = ref(storage, imagePath); // Path to the image
+
+  try {
+    await deleteObject(imageRef);
+    console.log("Image deleted successfully!");
+  } catch (error) {
+    console.error("Error deleting image:", error);
+  }
 };
 
 /**


### PR DESCRIPTION
## Summary

Vastly improved image handling. Notable changes:

1. Can now clear images in EventForm
![image](https://github.com/user-attachments/assets/d268291e-4975-4089-b82d-6b1825c9eabb)

2. When editing events, the current image now shows up:
![image](https://github.com/user-attachments/assets/23cd0a06-fdc4-4583-934e-a4d8cfa1eb0a)

3. Fixed: EventCards would show empty image. This is because when editing events in EventForm, the imageURL was not correctly being set to null (instead set to empty string). Now it's set to null, so the default placeholder image is shown.

![image](https://github.com/user-attachments/assets/065b22fd-8720-47e6-8a00-4a12db75d078)

4. When editing an event, if you select a new image and save it, the old image is now **deleted** from Firestore before the new one is uploaded.

5. Added security access rules to Firebase (also documented this in the handoff document). Volunteers can read all images. Only admins and supervisors can write.
```
rules_version = '2';

// Craft rules based on data in your Firestore database
// allow write: if firestore.get(
//    /databases/(default)/documents/users/$(request.auth.uid)).data.isAdmin;
service firebase.storage {
  match /b/{bucket}/o {

    // This rule allows anyone with your Storage bucket reference to view, edit,
    // and delete all data in your Storage bucket. It is useful for getting
    // started, but it is configured to expire after 30 days because it
    // leaves your app open to attackers. At that time, all client
    // requests to your Storage bucket will be denied.
    //
    // Make sure to write security rules for your app before that time, or else
    // all client requests to your Storage bucket will be denied until you Update
    // your rules
    match /{allPaths=**} {
      allow read, write: if request.time < timestamp.date(2024, 5, 14);
    }
    
    match /{document=**} {
      allow read: if request.auth != null;
			allow write: if request.auth.token.admin == true || request.auth.token.supervisor == true;
    }
  }
}
```

Closes:
- [BUG] Hide image in ViewEventDetails if no event image is set.

## Testing

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

## Notes

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->