### PR TITLE
Fix data refresh for event registration

### DIFF
--- a/frontend/src/components/organisms/EventCardCancel.tsx
+++ b/frontend/src/components/organisms/EventCardCancel.tsx
@@ -45,7 +45,7 @@ const ModalBody = ({ handleClose, mutateFn }: modalProps) => {
           alignItems: "center",
         }}
       >
-        <div>Are you sure you want to cancel?</div>
+        <div>Are you sure you want to cancel your registration?</div>
       </Box>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
         <div className="order-1 sm:order-2">
@@ -53,7 +53,7 @@ const ModalBody = ({ handleClose, mutateFn }: modalProps) => {
         </div>
         <div className="order-2 sm:order-1">
           <Button variety="secondary" onClick={handleClose}>
-            No
+            Cancel
           </Button>
         </div>
       </div>
@@ -106,6 +106,9 @@ const EventCardCancel = ({
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["event", eventId] });
+      queryClient.invalidateQueries({
+        queryKey: ["eventAttendance", eventId, attendeeId],
+      });
       handleClose();
     },
   });

--- a/frontend/src/components/organisms/EventCardRegister.tsx
+++ b/frontend/src/components/organisms/EventCardRegister.tsx
@@ -39,6 +39,9 @@ const EventCardRegister = ({
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["event", eventId] });
+      queryClient.invalidateQueries({
+        queryKey: ["eventAttendance", eventId, attendeeId],
+      });
     },
   });
 


### PR DESCRIPTION
## Summary

Fixes: when you click Register or Cancel on the ViewEventDetails page, it didn't do a page refresh to update the event details.

Closes:
- [BUG] When you register for an event, the page doesn't update/refresh

## Testing

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

## Notes

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->