### PR TITLE
Rename table columns for clarity

### DIFF
--- a/frontend/src/components/organisms/ManageAttendees.tsx
+++ b/frontend/src/components/organisms/ManageAttendees.tsx
@@ -202,7 +202,7 @@ const AttendeesTable = ({
     },
     {
       field: "status",
-      headerName: "Status",
+      headerName: "Registration status",
       sortable: false,
       minWidth: 175,
       flex: 0.5,

--- a/frontend/src/components/organisms/ManageUserProfileNew.tsx
+++ b/frontend/src/components/organisms/ManageUserProfileNew.tsx
@@ -52,7 +52,7 @@ interface ManageUserProfileNew {}
 const eventColumns: GridColDef[] = [
   {
     field: "name",
-    headerName: "Program Name",
+    headerName: "Event name",
     flex: 2,
     minWidth: 100,
     renderHeader: (params) => (

--- a/frontend/src/components/organisms/ViewEvents.tsx
+++ b/frontend/src/components/organisms/ViewEvents.tsx
@@ -172,7 +172,7 @@ const PastEvents = () => {
   const volunteerEventColumns: GridColDef[] = [
     {
       field: "name",
-      headerName: "Program Name",
+      headerName: "Event name",
       minWidth: 200,
       flex: 2,
       renderHeader: (params) => (
@@ -211,7 +211,7 @@ const PastEvents = () => {
     },
     {
       field: "attendeeStatus",
-      headerName: "Status",
+      headerName: "Registration status",
       sortable: false,
       minWidth: 150,
       renderHeader: (params) => (
@@ -242,7 +242,7 @@ const PastEvents = () => {
   const SupervisoreventColumns: GridColDef[] = [
     {
       field: "name",
-      headerName: "Program Name",
+      headerName: "Event name",
       minWidth: 200,
       flex: 1,
       renderHeader: (params) => (


### PR DESCRIPTION
## Summary

Rename "Status" to "Registration status" and "Program Name" to "Event name" for clarity

Closes:
- [bug] Status column in Past Events should be changed to Volunteer Status for clarity

## Testing

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

## Notes

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->