### PR TITLE
Add toggle in ViewEvents to see all events

### DIFF
--- a/frontend/src/components/atoms/Select.tsx
+++ b/frontend/src/components/atoms/Select.tsx
@@ -13,7 +13,7 @@ interface SelectProps {
 const Select = ({
   children,
   label,
-  error,
+  error = "",
   size = "medium",
   ...props
 }: SelectProps) => {
@@ -30,7 +30,7 @@ const Select = ({
 
   return (
     <div>
-      <div className="mb-1">{label}</div>
+      {label && <div className="mb-1">{label}</div>}
       <MuiSelect
         size="small"
         sx={{

--- a/frontend/src/components/organisms/EventCardNew.tsx
+++ b/frontend/src/components/organisms/EventCardNew.tsx
@@ -30,7 +30,7 @@ const EventCardContent = ({ event }: EventCardNewProps) => {
       ? `/events/${event.id}/attendees`
       : `/events/${event.id}/register`;
   const buttonText =
-    event.role === "Supervisor" ? "Manage Event" : "View Event Details";
+    event.role === "Supervisor" ? "Manage event" : "View event details";
 
   return (
     <div>

--- a/frontend/src/utils/AuthContext.tsx
+++ b/frontend/src/utils/AuthContext.tsx
@@ -16,7 +16,7 @@ import { UserCredential, onAuthStateChanged } from "firebase/auth";
 import { useRouter } from "next/router";
 import Loading from "@/components/molecules/Loading";
 
-type Role = "Volunteer" | "Supervisor" | "Admin";
+export type Role = "Volunteer" | "Supervisor" | "Admin";
 // Define types for authentication context value
 type AuthContextValue = {
   user: User | null | undefined;
@@ -210,7 +210,9 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
 
       return () => {
         router.events.off("routeChangeStart", hideContent);
-        router.events.off("routeChangeComplete", () => sessionStorage.removeItem("redirectPath"));
+        router.events.off("routeChangeComplete", () =>
+          sessionStorage.removeItem("redirectPath")
+        );
       };
     });
     return unsubscribe;

--- a/frontend/src/utils/useViewEventState.ts
+++ b/frontend/src/utils/useViewEventState.ts
@@ -16,7 +16,8 @@ import { useAuth } from "@/utils/AuthContext";
 
 function useViewEventState(
   role: "Supervisor" | "Volunteer" | "Admin",
-  state: "upcoming" | "past"
+  state: "upcoming" | "past",
+  seeAllEvents: boolean
 ) {
   const queryClient = useQueryClient();
 
@@ -51,7 +52,13 @@ function useViewEventState(
     const limit = prev ? -paginationModel.pageSize : paginationModel.pageSize;
     const whichUser =
       role === "Volunteer" ? `userid=${userid}` : `ownerid=${userid}`;
-    let url = `/events?${whichUser}&limit=${limit}&after=${cursor}&sort=${sortModel[0].field}:${sortModel[0].sort}&date=${state}&include=attendees`;
+
+    // Differentiate based on whether we want to grab all events or just those
+    // created by / registered to the current user
+    let url = seeAllEvents
+      ? `/events?limit=${limit}&after=${cursor}&sort=${sortModel[0].field}:${sortModel[0].sort}&date=${state}&include=attendees`
+      : `/events?${whichUser}&limit=${limit}&after=${cursor}&sort=${sortModel[0].field}:${sortModel[0].sort}&date=${state}&include=attendees`;
+
     const { response, data } = await api.get(url);
     return data;
   };


### PR DESCRIPTION
## Summary

Supervisors/admins can now click to see all events in the entire database, not just their own.
![image](https://github.com/user-attachments/assets/83349a90-f743-4a0e-843e-8cadbffc3ab7)

Closes:
- [NOT SURE IF IMPLEMENTED] Ensure all supervisors can see events created by all other supervisors.

## Testing

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

## Notes

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->