### PR TITLE
Improve event edit and cancel flow

### DIFF
--- a/backend/prisma/migrations/20250102030506_event_status/migration.sql
+++ b/backend/prisma/migrations/20250102030506_event_status/migration.sql
@@ -1,0 +1,19 @@
+/*
+  Warnings:
+
+  - The values [DRAFT,COMPLETED] on the enum `EventStatus` will be removed. If these variants are still used in the database, this will fail.
+
+*/
+-- AlterEnum
+BEGIN;
+CREATE TYPE "EventStatus_new" AS ENUM ('ACTIVE', 'CANCELED');
+ALTER TABLE "Event" ALTER COLUMN "status" DROP DEFAULT;
+ALTER TABLE "Event" ALTER COLUMN "status" TYPE "EventStatus_new" USING ("status"::text::"EventStatus_new");
+ALTER TYPE "EventStatus" RENAME TO "EventStatus_old";
+ALTER TYPE "EventStatus_new" RENAME TO "EventStatus";
+DROP TYPE "EventStatus_old";
+ALTER TABLE "Event" ALTER COLUMN "status" SET DEFAULT 'ACTIVE';
+COMMIT;
+
+-- AlterTable
+ALTER TABLE "Event" ALTER COLUMN "status" SET DEFAULT 'ACTIVE';

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -80,7 +80,7 @@ model Event {
   startDate    DateTime
   endDate      DateTime
   mode         EventMode?        @default(IN_PERSON)
-  status       EventStatus?      @default(DRAFT)
+  status       EventStatus?      @default(ACTIVE)
   owner        User              @relation(fields: [ownerId], references: [id], name: "EventOwner")
   ownerId      String
   attendees    EventEnrollment[]
@@ -137,9 +137,7 @@ enum UserStatus {
 }
 
 enum EventStatus {
-  DRAFT
   ACTIVE
-  COMPLETED
   CANCELED
 }
 

--- a/frontend/src/components/organisms/EventCardCancel.tsx
+++ b/frontend/src/components/organisms/EventCardCancel.tsx
@@ -17,6 +17,7 @@ interface EventCardCancelProps {
   eventId: string;
   attendeeStatus: string;
   date: Date;
+  eventCanceled: boolean;
 }
 
 interface modalProps {
@@ -66,6 +67,7 @@ const EventCardCancel = ({
   attendeeId,
   attendeeStatus,
   date,
+  eventCanceled,
 }: EventCardCancelProps) => {
   const { user } = useAuth();
   const queryClient = useQueryClient();
@@ -155,6 +157,11 @@ const EventCardCancel = ({
             You have passed the window for canceling your registration.
             Registration must be canceled at least 24 hours before the event
             begins. Failure to do so may affect your volunteer status.
+          </div>
+        ) : eventCanceled ? (
+          <div>
+            The event has been canceled. You are no longer able to cancel your
+            registration.
           </div>
         ) : attendeeStatus !== "PENDING" ? (
           <div>

--- a/frontend/src/components/organisms/EventCardRegister.tsx
+++ b/frontend/src/components/organisms/EventCardRegister.tsx
@@ -11,6 +11,7 @@ interface EventRegisterCardProps {
   overCapacity: boolean;
   attendeeId: string;
   date: Date;
+  eventCanceled: boolean;
 }
 
 const EventCardRegister = ({
@@ -18,6 +19,7 @@ const EventCardRegister = ({
   overCapacity,
   attendeeId,
   date,
+  eventCanceled,
 }: EventRegisterCardProps) => {
   const { user } = useAuth();
   const queryClient = useQueryClient();
@@ -47,7 +49,7 @@ const EventCardRegister = ({
 
   /** Register button should be disabled if event is in the past */
   const currentDate = new Date();
-  const disableRegisterEvent = date < currentDate;
+  const eventInPast = date < currentDate;
 
   return (
     <Card>
@@ -62,11 +64,13 @@ const EventCardRegister = ({
       <div className="mt-3" />
       <CustomCheckbox
         label="I agree to the terms and conditions"
-        disabled={disableRegisterEvent || overCapacity}
+        disabled={eventCanceled || eventInPast || overCapacity}
         onChange={() => setIsChecked(!isChecked)}
       />
       <div className="mt-3" />
-      {disableRegisterEvent ? (
+      {eventCanceled ? (
+        <Button disabled>The event has been canceled.</Button>
+      ) : eventInPast ? (
         <Button disabled>The event has concluded.</Button>
       ) : overCapacity ? (
         <Button disabled>The event has reached capacity.</Button>

--- a/frontend/src/components/organisms/EventForm.tsx
+++ b/frontend/src/components/organisms/EventForm.tsx
@@ -356,7 +356,8 @@ const EventForm = ({
       {eventType == "edit" && eventIsPast && (
         <div className="pb-6">
           <Alert variety="warning">
-            This event is in the past. You are not able to make changes.
+            This event has already started or is in the past. You are not able
+            to make changes or cancel the event.
           </Alert>
         </div>
       )}

--- a/frontend/src/components/organisms/EventForm.tsx
+++ b/frontend/src/components/organisms/EventForm.tsx
@@ -84,7 +84,7 @@ const EventForm = ({
   // For deciding whether to show "In-person" or "Virtual"
   // 0: no show, 1: show yes.
   const [status, setStatus] = React.useState(
-    eventDetails ? (eventDetails.mode === "IN_PERSON" ? 1 : 0) : 0
+    eventDetails ? (eventDetails.mode === "IN_PERSON" ? 1 : 0) : 1
   );
   const radioHandler = (status: number) => {
     setStatus(status);
@@ -230,7 +230,7 @@ const EventForm = ({
           queryKey: ["event", eventId],
         });
         localStorage.setItem("eventEdited", "true");
-        router.push("/events/view");
+        router.push(`/events/${eventId}/attendees`);
       },
     });
 
@@ -249,7 +249,7 @@ const EventForm = ({
           queryKey: ["event", eventId],
         });
         localStorage.setItem("eventCanceled", "true");
-        router.push("/events/view");
+        router.push(`/events/${eventId}/attendees`);
       },
     });
 
@@ -496,10 +496,9 @@ const EventForm = ({
                   })}
                 />
                 <TextField
-                  placeholder="(Optional) Link to virtual meeting"
+                  placeholder="(Optional) Link to meeting"
                   error={errors.locationLink?.message}
                   {...register("locationLink", {
-                    required: { value: true, message: "Required" },
                     pattern: {
                       value: /^(https?|ftp):\/\/[^\s/$.?#].[^\s]*$/i,
                       message: "Invalid URL",

--- a/frontend/src/components/organisms/ManageAttendees.tsx
+++ b/frontend/src/components/organisms/ManageAttendees.tsx
@@ -214,6 +214,7 @@ const AttendeesTable = ({
         <div className="w-full">
           <Select
             size="small"
+            disabled={eventData.status === "CANCELED"}
             value={params.row.status}
             onChange={(event: any) =>
               handleStatusChange(params.row.id, event.target.value)

--- a/frontend/src/components/organisms/ManageAttendees.tsx
+++ b/frontend/src/components/organisms/ManageAttendees.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, FormEvent, useState } from "react";
+import React, { ChangeEvent, FormEvent, useEffect, useState } from "react";
 import TabContainer from "@/components/molecules/TabContainer";
 import {
   GridColDef,
@@ -40,6 +40,7 @@ import { BASE_WEBSOCKETS_URL } from "@/utils/constants";
 import useManageAttendeeState from "@/utils/useManageAttendeeState";
 import ManageSearchIcon from "@mui/icons-material/ManageSearch";
 import MultilineTextField from "../atoms/MultilineTextField";
+import Alert from "../atoms/Alert";
 
 type attendeeData = {
   id: number;
@@ -653,6 +654,7 @@ const ManageAttendees = () => {
     supervisors,
     description,
     name,
+    event_status,
   }: EventData = {
     eventid: eventData.id,
     location: eventData.location,
@@ -666,6 +668,7 @@ const ManageAttendees = () => {
     ],
     description: eventData.description,
     name: eventData.name,
+    event_status: eventData.status,
   };
 
   const dateHeader = formatDateTimeToUI(datetime);
@@ -795,8 +798,41 @@ const ManageAttendees = () => {
     },
   });
 
+  // Handles success modals for completing event editing and event cancellation
+  const [isEventEdited, setIsEventEdited] = useState(false);
+  const [isEventCanceled, setIsEventCanceled] = useState(false);
+
+  useEffect(() => {
+    if (localStorage.getItem("eventEdited")) {
+      setIsEventEdited(true);
+      localStorage.removeItem("eventEdited");
+    }
+    if (localStorage.getItem("eventCanceled")) {
+      setIsEventCanceled(true);
+      localStorage.removeItem("eventCanceled");
+    }
+  }, []);
+
   return (
     <>
+      {/* Event editing success notification */}
+      <Snackbar
+        variety="success"
+        open={isEventEdited}
+        onClose={() => setIsEventEdited(false)}
+      >
+        Your event has been successfully updated!
+      </Snackbar>
+
+      {/* Event canceled success notification */}
+      <Snackbar
+        variety="success"
+        open={isEventCanceled}
+        onClose={() => setIsEventCanceled(false)}
+      >
+        Your event has been successfully canceled!
+      </Snackbar>
+
       {/* Notifications */}
       <Snackbar
         variety="error"
@@ -821,6 +857,14 @@ const ManageAttendees = () => {
       />
 
       {/* Manage event */}
+      {event_status === "CANCELED" && (
+        <div className="pb-6">
+          <Alert variety="warning">
+            This event has been canceled. You are not able to make changes, and
+            this event will not count towards any volunteer hours.
+          </Alert>
+        </div>
+      )}
       <div className="flex flex-col sm:flex-row sm:justify-between pb-6 sm:pb-4">
         <div className="font-semibold text-3xl mb-6">{name}</div>
         <div className="flex flex-col sm:flex-row gap-4">

--- a/frontend/src/components/organisms/ViewEventDetails.tsx
+++ b/frontend/src/components/organisms/ViewEventDetails.tsx
@@ -29,6 +29,7 @@ import FetchDataError from "./FetchDataError";
 import EventDetails from "./EventDetails";
 import useWebSocket from "react-use-websocket";
 import { BASE_WEBSOCKETS_URL } from "@/utils/constants";
+import Alert from "../atoms/Alert";
 
 interface ViewEventDetailsProps {}
 
@@ -107,6 +108,7 @@ const ViewEventDetails = () => {
     supervisors,
     description,
     name,
+    event_status,
   }: EventData = {
     eventid: eventData.id,
     location: eventData.location,
@@ -120,6 +122,7 @@ const ViewEventDetails = () => {
     ],
     description: eventData.description,
     name: eventData.name,
+    event_status: eventData.status,
   };
 
   const dateHeader = formatDateTimeToUI(datetime);
@@ -137,6 +140,15 @@ const ViewEventDetails = () => {
     <EventTemplate
       header={
         <div>
+          {event_status === "CANCELED" && (
+            <div className="pb-6">
+              <Alert variety="warning">
+                This event has been canceled. You are not allowed to change your
+                registration status, and this event will not count towards any
+                volunteer hours.
+              </Alert>
+            </div>
+          )}
           <div className="font-semibold text-3xl">{name}</div>
           <div className="mt-5" />
           <div className="grid gap-2 xl:gap-6 xl:grid-cols-2">

--- a/frontend/src/components/organisms/ViewEventDetails.tsx
+++ b/frontend/src/components/organisms/ViewEventDetails.tsx
@@ -215,6 +215,7 @@ const ViewEventDetails = () => {
                 attendeeStatus={eventAttendance.attendeeStatus}
                 attendeeId={userid}
                 date={new Date(eventData.startDate)}
+                eventCanceled={event_status === "CANCELED"}
               />
             ) : (
               <EventCardRegister
@@ -222,6 +223,7 @@ const ViewEventDetails = () => {
                 overCapacity={registeredVolunteersNumber === capacity}
                 attendeeId={userid}
                 date={new Date(eventData.startDate)}
+                eventCanceled={event_status === "CANCELED"}
               />
             )}
           </div>

--- a/frontend/src/components/organisms/ViewEvents.tsx
+++ b/frontend/src/components/organisms/ViewEvents.tsx
@@ -466,22 +466,12 @@ const ViewEvents = () => {
   ];
 
   const [isEventCreated, setIsEventCreated] = useState(false);
-  const [isEventEdited, setIsEventEdited] = useState(false);
-  const [isEventCanceled, setIsEventCanceled] = useState(false);
 
   useEffect(() => {
     const isEventCreated = localStorage.getItem("eventCreated");
     if (isEventCreated) {
       setIsEventCreated(true);
       localStorage.removeItem("eventCreated");
-    }
-    if (localStorage.getItem("eventEdited")) {
-      setIsEventEdited(true);
-      localStorage.removeItem("eventEdited");
-    }
-    if (localStorage.getItem("eventCanceled")) {
-      setIsEventCanceled(true);
-      localStorage.removeItem("eventCanceled");
     }
   }, []);
 
@@ -494,24 +484,6 @@ const ViewEvents = () => {
         onClose={() => setIsEventCreated(false)}
       >
         Your event was successfully created!
-      </Snackbar>
-
-      {/* Event editing success notification */}
-      <Snackbar
-        variety="success"
-        open={isEventEdited}
-        onClose={() => setIsEventEdited(false)}
-      >
-        Your event has been successfully updated!
-      </Snackbar>
-
-      {/* Event canceled success notification */}
-      <Snackbar
-        variety="success"
-        open={isEventCanceled}
-        onClose={() => setIsEventCanceled(false)}
-      >
-        Your event has been successfully canceled!
       </Snackbar>
 
       <TabContainer

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -27,6 +27,7 @@ export type EventData = {
   tags: string[] | undefined;
   description: string;
   name: string;
+  event_status: string;
 };
 
 export type EventDTO = {


### PR DESCRIPTION
## Summary

When you finish editing/canceling an event, you are redirected to ManageAttendees instead of ViewEvents. Also, canceled events are more noticeable

![image](https://github.com/user-attachments/assets/db29b44d-890d-4da2-8856-e01c82a67709)

![image](https://github.com/user-attachments/assets/63cb69f0-895e-4172-9c63-8f262e557273)

Volunteers can't register for or cancel registration for canceled events
![image](https://github.com/user-attachments/assets/57d8f764-28f5-4075-a2c1-5c007dd6a1dc)

Supervisors can't change the registration status of users in canceled events
![image](https://github.com/user-attachments/assets/037ee61f-6102-4425-a497-5042e2dfac6d)

Better message to tell supervisors they can't cancel an event that's already started
![image](https://github.com/user-attachments/assets/272300a7-2cfa-4dbb-9291-f4dfb45e7d23)


Closes:
- [feature] If event is canceled, it should show up in Manage Event page
- [BUG] After editing an event, you should be redirected to the Manage Event page, not the View Events page.
- [bug] Volunteers can still register for canceled events
- Should not be able to register if event is canceled - some more functionality should be hidden too. 
- Add an Alert to ManageEvent and ViewEventDetails to show that an event has been canceled (currently it only appears on EventCardNew and in EventForm)
- Cannot cancel event that has already started (but hasn’t ended yet). This may be intended behavior, but if so we need to make it consistent.
- People can take action after event has been canceled

## Testing

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

## Notes

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->