### PR TITLE
Fix hour tracking in ManageUsers, ManageUserProfileNew, PastEvents

### DIFF
--- a/backend/src/users/controllers.ts
+++ b/backend/src/users/controllers.ts
@@ -1,5 +1,5 @@
 import { Request, Response, query } from "express";
-import { Prisma, userRole, UserStatus } from "@prisma/client";
+import { EventStatus, Prisma, userRole, UserStatus } from "@prisma/client";
 import {
   User,
   Profile,
@@ -489,6 +489,9 @@ const getHours = async (userId: string) => {
     where: {
       userId: userId,
       attendeeStatus: "CHECKED_OUT",
+      event: {
+        status: EventStatus.ACTIVE,
+      },
     },
     include: {
       event: true,

--- a/frontend/src/components/organisms/ManageUserProfileNew.tsx
+++ b/frontend/src/components/organisms/ManageUserProfileNew.tsx
@@ -479,7 +479,9 @@ const ManageUserProfileNew = () => {
       <h3>Hour Tracker</h3>
       <div className="grid gap-4 md:grid-cols-2">
         <Card>
-          <LinearProgress value={100 * (hours / REFERENCE_HOURS)} />
+          <LinearProgress
+            value={Math.min(100, 100 * (hours / REFERENCE_HOURS))}
+          />
           <h3 className="mb-2 mt-4">Reference Hour Tracker</h3>
           <div>
             {friendlyHours(hours)} / {REFERENCE_HOURS} hours complete
@@ -487,7 +489,9 @@ const ManageUserProfileNew = () => {
           {/* <Button>Approve Reference Request</Button> */}
         </Card>
         <Card>
-          <LinearProgress value={100 * (hours / CERTIFICATE_HOURS)} />
+          <LinearProgress
+            value={Math.min(100, 100 * (hours / CERTIFICATE_HOURS))}
+          />
           <h3 className="mb-2 mt-4">Certificate Hour Tracker</h3>
           <div>
             {friendlyHours(hours)} / {CERTIFICATE_HOURS} hours complete

--- a/frontend/src/components/organisms/ViewEvents.tsx
+++ b/frontend/src/components/organisms/ViewEvents.tsx
@@ -13,6 +13,7 @@ import {
   convertEnrollmentStatusToString,
   eventHours,
   fetchUserIdFromDatabase,
+  friendlyHours,
 } from "@/utils/helpers";
 import { Action, ViewEventsEvent } from "@/utils/types";
 import Select from "../atoms/Select";
@@ -365,10 +366,12 @@ const PastEvents = ({
         <>
           <div className="grid gap-4 md:grid-cols-2 pb-4">
             <Card>
-              <LinearProgress value={100 * (hours / REFERENCE_HOURS)} />
+              <LinearProgress
+                value={Math.min(100, 100 * (hours / REFERENCE_HOURS))}
+              />
               <h3 className="mb-2 mt-4">Reference Hour Tracker</h3>
               <div className="mb-4">
-                {hours} / {REFERENCE_HOURS} hours complete
+                {friendlyHours(hours)} / {REFERENCE_HOURS} hours complete
               </div>
               <div>
                 You must complete a minimum of 80 hours, have photo proof, and
@@ -379,10 +382,12 @@ const PastEvents = ({
               </div> */}
             </Card>
             <Card>
-              <LinearProgress value={100 * (hours / CERTIFICATE_HOURS)} />
+              <LinearProgress
+                value={Math.min(100, 100 * (hours / CERTIFICATE_HOURS))}
+              />
               <h3 className="mb-2 mt-4">Certificate Hour Tracker</h3>
               <div className="mb-4">
-                {hours} / {CERTIFICATE_HOURS} hours complete
+                {friendlyHours(hours)} / {CERTIFICATE_HOURS} hours complete
               </div>
               <div>
                 You must complete a minimum of 120 hours, have photo proof, and

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -97,7 +97,20 @@ export const eventHours = (endTime: string, startTime: string) => {
   const end = new Date(endTime);
   const diff = end.getTime() - start.getTime();
   const hours = diff / (1000 * 3600);
-  return Math.round(hours);
+
+  return friendlyHours(hours);
+};
+
+/**
+ * Converts "8.53" hours into "8 hrs 32 min"
+ * @param hours is the number of hours
+ * @returns hours and mins
+ */
+export const friendlyHours = (hours: number) => {
+  const wholeHours = Math.floor(hours);
+  const minutes = Math.round((hours - wholeHours) * 60);
+
+  return `${wholeHours} hrs ${minutes} min`;
 };
 
 /**

--- a/frontend/src/utils/useManageUserState.ts
+++ b/frontend/src/utils/useManageUserState.ts
@@ -5,7 +5,7 @@ import {
   useQuery,
 } from "@tanstack/react-query";
 import { api } from "./api";
-import { formatRoleOrStatus } from "@/utils/helpers";
+import { formatRoleOrStatus, friendlyHours } from "@/utils/helpers";
 import { GridPaginationModel, GridSortModel } from "@mui/x-data-grid";
 
 function useManageUserState(state: "ACTIVE" | "INACTIVE") {
@@ -77,7 +77,7 @@ function useManageUserState(state: "ACTIVE" | "INACTIVE") {
       email: user.email,
       role: formatRoleOrStatus(user.role),
       createdAt: new Date(user.createdAt),
-      hours: user.hours, // TODO: properly calculate hours
+      hours: friendlyHours(user.totalHours),
     });
   });
 

--- a/frontend/src/utils/useViewEventState.ts
+++ b/frontend/src/utils/useViewEventState.ts
@@ -84,7 +84,6 @@ function useViewEventState(
       const userid = await fetchUserIdFromDatabase(user?.email as string);
       const hours = await api.get(`/users/${userid}/hours`);
       setUserid(userid);
-      setHours(hours.data["data"]);
       return await fetchBatchOfEvents(userid);
     },
     placeholderData: keepPreviousData,
@@ -94,6 +93,13 @@ function useViewEventState(
   const rows: any[] = [];
   const totalNumberofData = data?.data.totalItems;
   data?.data.result.map((event: any) => {
+    let attendeeStatus =
+      event.attendees.length > 0
+        ? convertEnrollmentStatusToString(
+            event.attendees["0"]["attendeeStatus"]
+          )
+        : undefined;
+
     rows.push({
       id: event.id,
       name: event.name,
@@ -101,14 +107,12 @@ function useViewEventState(
       startDate: formatDateString(event.startDate),
       endDate: new Date(event.endDate),
       role: event.role,
-      hours: eventHours(event.endDate, event.startDate),
+      hours:
+        attendeeStatus === "Checked out"
+          ? eventHours(event.endDate, event.startDate)
+          : "N/A",
       status: event.status,
-      attendeeStatus:
-        event.attendees.length > 0
-          ? convertEnrollmentStatusToString(
-              event.attendees["0"]["attendeeStatus"]
-            )
-          : undefined,
+      attendeeStatus: attendeeStatus,
     });
   });
 

--- a/frontend/src/utils/useViewEventState.ts
+++ b/frontend/src/utils/useViewEventState.ts
@@ -23,7 +23,16 @@ function useViewEventState(
 
   const { user } = useAuth();
   const [userid, setUserid] = useState<string>("");
-  const [hours, setHours] = useState<number>(0);
+
+  /** Tanstack query for fetching the user's total hours */
+  const hoursQuery = useQuery({
+    queryKey: ["userHours", userid],
+    queryFn: async () => {
+      const { data: dataHours } = await api.get(`/users/${userid}/hours`);
+      return dataHours["data"];
+    },
+  });
+  let hours = hoursQuery.data;
 
   /** Pagination model for the table */
   const [paginationModel, setPaginationModel] = useState<GridPaginationModel>({


### PR DESCRIPTION
## Summary

Hours are correctly tracked everywhere in all three components

![image](https://github.com/user-attachments/assets/76c69154-655a-4962-92a8-57d2559e9bd7)

![image](https://github.com/user-attachments/assets/7d32fe80-8bf3-420f-81f6-bccadb156633)
![image](https://github.com/user-attachments/assets/f44ba705-7f48-4c78-ba93-57986cacf8d6)


Closes:
- Should canceled events count toward the number of hours? (no, only ACTIVE events are counted in the backend query)

## Testing

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

## Notes

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->