### PR TITLE
Show green button in EventCardNew only for events today

### DIFF
--- a/frontend/src/components/organisms/EventCardNew.tsx
+++ b/frontend/src/components/organisms/EventCardNew.tsx
@@ -53,7 +53,11 @@ const EventCardContent = ({ event }: EventCardNewProps) => {
       <div className="mt-3" />
       {/* Bad UX behavior: Looks like button is as wide as length of location so it looks different with different event.  */}
       <Link href={url}>
-        <Button>{buttonText}</Button>
+        <Button
+          variety={displayDateInfo(date) === "Today" ? "primary" : "secondary"}
+        >
+          {buttonText}
+        </Button>
       </Link>
     </div>
   );


### PR DESCRIPTION
## Summary

![image](https://github.com/user-attachments/assets/032451a8-2f39-4254-841e-52ad21318aa6)

Closes:
- [FEATURE] Upcoming events that are not super close should have white button not green

## Testing

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

## Notes

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->