### PR TITLE
Fix event image box sizing for EventCardNew

### DIFF
--- a/frontend/src/components/organisms/EventCardNew.tsx
+++ b/frontend/src/components/organisms/EventCardNew.tsx
@@ -112,7 +112,7 @@ const EventCardNew = ({ event }: EventCardNewProps) => {
               <div className="flex-1 hidden md:block md:pl-6">
                 <div className="relative h-full w-full overflow-auto rounded-2xl">
                   <img
-                    className="absolute right-0 h-full rounded-2xl w-[300px] object-cover border-gray-300 border-solid border"
+                    className="absolute right-0 h-full rounded-2xl w-[300px] object-cover border-gray-300 border-solid border box-border"
                     src={
                       event.imageURL == null
                         ? "/lfbi_splash.png"


### PR DESCRIPTION
## Summary

<!-- Summarize your changes here. -->
Closes:
- [BUG] Event card image is just a tinnnnyyy bit too large, so you end up scrolling on the image a bit

## Testing

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

## Notes

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->