### PR TITLE
Fix overflow clip of image in ViewEventDetails

### DIFF
--- a/frontend/src/components/templates/EventTemplate.tsx
+++ b/frontend/src/components/templates/EventTemplate.tsx
@@ -26,8 +26,8 @@ const EventTemplate = ({ header, body, img, card }: EventTemplateProps) => {
 
         {/* Right column */}
         <div className="w-96">
-          <div className="max-h-96 overflow-hidden">{img}</div>
-          <div className="mt-6 sticky top-5">{card}</div>
+          <div>{img}</div>
+          <div className="mt-8 sticky">{card}</div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

Before:
![image](https://github.com/user-attachments/assets/4cf98b02-fc2a-482b-a856-4bbd18bc8a37)

After:
![image](https://github.com/user-attachments/assets/fa812ef4-55c8-4054-a084-e86bd682d4cd)

Closes:
- [BUG} If you have a large height image in ViewEventDetails, the bottom of the image is cut off.

## Testing

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

## Notes

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->