### PR TITLE
Fix: dropzone allows you to reupload same image after clearing

### DIFF
--- a/frontend/src/components/atoms/Dropzone.tsx
+++ b/frontend/src/components/atoms/Dropzone.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import Button from "./Button";
 
 interface DropzoneProps {
@@ -20,6 +20,7 @@ const Dropzone = ({
   label,
   ...props
 }: DropzoneProps) => {
+  const fileInputRef = useRef<HTMLInputElement | null>(null); // Ref for the file input
   const allowedFileTypes = ["image/jpg", "image/jpeg", "image/png"];
   const maxFileSize = 50 * 1024 * 1024; // 50 MB
 
@@ -51,6 +52,10 @@ const Dropzone = ({
     event.preventDefault();
     event.target.value = null;
     setSelectedFile(null);
+
+    if (fileInputRef.current) {
+      fileInputRef.current.value = ""; // Reset file input
+    }
   };
 
   return (
@@ -118,6 +123,7 @@ const Dropzone = ({
             onChange={handleFileChange}
             type="file"
             className="hidden"
+            ref={fileInputRef}
           />
         </label>
       </div>

--- a/frontend/src/components/atoms/Dropzone.tsx
+++ b/frontend/src/components/atoms/Dropzone.tsx
@@ -75,7 +75,7 @@ const Dropzone = ({
         </div>
       </div>
       <div className="flex items-center justify-center w-full">
-        <label className="flex flex-col items-center justify-center w-full h-32 border-2 border-gray-300 border-dashed rounded-lg cursor-pointer hover:bg-gray-50">
+        <label className="flex flex-col items-center justify-center w-full h-32 border-2 border-gray-300 border-dashed rounded-lg cursor-pointer hover:bg-gray-50 overflow-hidden">
           <div className="flex flex-col items-center justify-center pt-5 pb-6">
             {props.defaultValue ? (
               <div className="flex items-center">


### PR DESCRIPTION
## Summary

<!-- Summarize your changes here. -->
Closes:
- [BUG] If you upload Event Image in EventForm, clear the image, then try to attach the same image again, it doesn't let you (you have to refresh the page)
- [UI BUG] Dropzone image exceeds width if image too wide

![image](https://github.com/user-attachments/assets/a1b22c9b-bb0e-4739-af2a-6f2a8ffd503f)


## Testing

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

## Notes

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->