### PR TITLE
Fix supervisor permissions

### DIFF
--- a/backend/src/about/views.ts
+++ b/backend/src/about/views.ts
@@ -3,7 +3,7 @@ import {
   auth,
   NoAuth,
   authIfAdmin,
-  authIfSupervisor,
+  authIfSupervisorOrAdmin,
 } from "../middleware/auth";
 import { attempt } from "../utils/helpers";
 import aboutController from "./controllers";
@@ -20,7 +20,7 @@ process.env.NODE_ENV === "test"
     (useSupervisorAuth = NoAuth as RequestHandler))
   : ((useAuth = auth as RequestHandler),
     (useAdminAuth = authIfAdmin as RequestHandler),
-    (useSupervisorAuth = authIfSupervisor as RequestHandler));
+    (useSupervisorAuth = authIfSupervisorOrAdmin as RequestHandler));
 
 aboutRouter.get("/", useAuth, async (req: Request, res: Response) => {
   attempt(res, 200, () => aboutController.getAboutPageContent());

--- a/backend/src/events/views.ts
+++ b/backend/src/events/views.ts
@@ -4,7 +4,7 @@ import {
   auth,
   NoAuth,
   authIfAdmin,
-  authIfSupervisor,
+  authIfSupervisorOrAdmin,
   authIfVolunteer,
 } from "../middleware/auth";
 import { attempt, socketNotify } from "../utils/helpers";
@@ -16,15 +16,15 @@ const eventRouter = Router();
 
 let useAuth: RequestHandler;
 let useAdminAuth: RequestHandler;
-let useSupervisorAuth: RequestHandler;
+let useSupervisorAdminAuth: RequestHandler;
 
 process.env.NODE_ENV === "test"
   ? ((useAuth = NoAuth as RequestHandler),
     (useAdminAuth = NoAuth as RequestHandler),
-    (useSupervisorAuth = NoAuth as RequestHandler))
+    (useSupervisorAdminAuth = NoAuth as RequestHandler))
   : ((useAuth = auth as RequestHandler),
     (useAdminAuth = authIfAdmin as RequestHandler),
-    (useSupervisorAuth = authIfSupervisor as RequestHandler));
+    (useSupervisorAdminAuth = authIfSupervisorOrAdmin as RequestHandler));
 
 export type EventDTO = {
   userID: string;
@@ -44,7 +44,7 @@ export type EventDTO = {
 
 eventRouter.post(
   "/",
-  useAdminAuth || useSupervisorAuth,
+  useSupervisorAdminAuth,
   async (req: Request, res: Response) => {
     // #swagger.tags = ['Events']
     const eventDTO: EventDTO = req.body;
@@ -55,7 +55,7 @@ eventRouter.post(
 
 eventRouter.put(
   "/:eventid",
-  useAdminAuth || useSupervisorAuth,
+  useSupervisorAdminAuth,
   async (req: Request, res: Response) => {
     // #swagger.tags = ['Events']
     attempt(res, 200, () =>
@@ -67,7 +67,7 @@ eventRouter.put(
 
 eventRouter.delete(
   "/:eventid",
-  useAdminAuth || useSupervisorAuth,
+  useSupervisorAdminAuth,
   async (req: Request, res: Response) => {
     // #swagger.tags = ['Events']
     attempt(res, 200, () => eventController.deleteEvent(req.params.eventid));
@@ -171,7 +171,7 @@ eventRouter.post(
 
 eventRouter.patch(
   "/:eventid/attendees/:userid/attendee-status",
-  useAdminAuth || useSupervisorAuth,
+  useSupervisorAdminAuth,
   async (req: Request, res: Response) => {
     // #swagger.tags = ['Events']
     const { attendeeStatus } = req.body;
@@ -205,7 +205,7 @@ eventRouter.put(
 
 eventRouter.patch(
   "/:eventid/status",
-  useAdminAuth || useSupervisorAuth,
+  useSupervisorAdminAuth,
   async (req: Request, res: Response) => {
     // #swagger.tags = ['Events']
     const { status } = req.body;
@@ -218,7 +218,7 @@ eventRouter.patch(
 
 eventRouter.patch(
   "/:eventid/owner",
-  useAdminAuth || useSupervisorAuth,
+  useSupervisorAdminAuth,
   async (req: Request, res: Response) => {
     // #swagger.tags = ['Events']
     const { ownerid } = req.body;
@@ -230,7 +230,7 @@ eventRouter.patch(
 
 eventRouter.patch(
   "/:eventid/attendees/:attendeeid/confirm",
-  useAdminAuth || useSupervisorAuth,
+  useSupervisorAdminAuth,
   async (req: Request, res: Response) => {
     // #swagger.tags = ['Events']
     attempt(res, 200, () =>

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -83,10 +83,10 @@ export const authIfVolunteer = (
 };
 
 /**
- * Authorizes a request if a token is present with the supervisor claim,
+ * Authorizes a request if a token is present with the supervisor or admin claim,
  * returning an error otherwise.
  */
-export const authIfSupervisor = (
+export const authIfSupervisorOrAdmin = (
   req: IGetAuthTokenRequest,
   res: Response,
   next: NextFunction
@@ -94,7 +94,7 @@ export const authIfSupervisor = (
   getAuthToken(req, res, async () => {
     try {
       const userInfo = await firebase.auth().verifyIdToken(req.authToken);
-      if (userInfo.supervisor === true) {
+      if (userInfo.supervisor === true || userInfo.admin === true) {
         req.authId = userInfo.uid;
         return next();
       }

--- a/backend/src/users/views.ts
+++ b/backend/src/users/views.ts
@@ -8,7 +8,7 @@ import {
   updateFirebaseUserToAdmin,
   NoAuth,
   authIfAdmin,
-  authIfSupervisor,
+  authIfSupervisorOrAdmin,
 } from "../middleware/auth";
 const userRouter = Router();
 import * as firebase from "firebase-admin";
@@ -17,15 +17,15 @@ import admin from "firebase-admin";
 
 let useAuth: RequestHandler;
 let useAdminAuth: RequestHandler;
-let useSupervisorAuth: RequestHandler;
+let useSupervisorAdminAuth: RequestHandler;
 
 process.env.NODE_ENV === "test"
   ? ((useAuth = NoAuth as RequestHandler),
     (useAdminAuth = NoAuth as RequestHandler),
-    (useSupervisorAuth = NoAuth as RequestHandler))
+    (useSupervisorAdminAuth = NoAuth as RequestHandler))
   : ((useAuth = auth as RequestHandler),
     (useAdminAuth = authIfAdmin as RequestHandler),
-    (useSupervisorAuth = authIfSupervisor as RequestHandler));
+    (useSupervisorAdminAuth = authIfSupervisorOrAdmin as RequestHandler));
 
 userRouter.post(
   "/",
@@ -129,7 +129,7 @@ userRouter.put("/:userid", useAuth, async (req: Request, res: Response) => {
 
 userRouter.get(
   "/count",
-  useAdminAuth || useSupervisorAuth,
+  useSupervisorAdminAuth,
   async (req: Request, res: Response) => {
     // #swagger.tags = ['Users']
     attempt(res, 200, userController.getCountUsers);
@@ -176,7 +176,7 @@ userRouter.get("/", useAuth, async (req: Request, res: Response) => {
 
 userRouter.get(
   "/pagination",
-  useAdminAuth || useSupervisorAuth,
+  useSupervisorAdminAuth,
   async (req: Request, res: Response) => {
     // #swagger.tags = ['Users']
     attempt(res, 200, () => userController.getUsersPaginated(req));
@@ -203,7 +203,7 @@ userRouter.get("/search", useAuth, async (req: Request, res: Response) => {
 
 userRouter.get(
   "/sorting",
-  useAdminAuth || useSupervisorAuth,
+  useSupervisorAdminAuth,
   async (req: Request, res: Response) => {
     // #swagger.tags = ['Users']
     attempt(res, 200, () => userController.getUsersSorted(req));
@@ -349,7 +349,7 @@ userRouter.patch(
 
 userRouter.patch(
   "/:userid/hours",
-  useAdminAuth || useSupervisorAuth,
+  useSupervisorAdminAuth,
   async (req: Request, res: Response) => {
     // #swagger.tags = ['Users']
     const { hours } = req.body;


### PR DESCRIPTION
## Summary

Fix: Supervisors didn't actually have permissions, because `useAdminAuth || useSupervisorAuth` didn't actually work since it would get stuck on the adminAuth and reject. Fixed by changing it to `useSupervisorAdminAuth`

## Testing

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

## Notes

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->