### PR TITLE
Fix deleting users

### DIFF
--- a/backend/api-spec.json
+++ b/backend/api-spec.json
@@ -147,11 +147,46 @@
             "name": "limit",
             "in": "query",
             "type": "string"
+          },
+          {
+            "name": "include",
+            "in": "query",
+            "type": "string"
           }
         ],
         "responses": {
           "default": {
             "description": ""
+          }
+        }
+      }
+    },
+    "/users/google": {
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "rest": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "500": {
+            "description": "Internal Server Error"
           }
         }
       }
@@ -600,6 +635,11 @@
             "name": "limit",
             "in": "query",
             "type": "string"
+          },
+          {
+            "name": "include",
+            "in": "query",
+            "type": "string"
           }
         ],
         "responses": {
@@ -716,11 +756,6 @@
             "in": "path",
             "required": true,
             "type": "string"
-          },
-          {
-            "name": "userid",
-            "in": "query",
-            "type": "string"
           }
         ],
         "responses": {
@@ -759,8 +794,10 @@
             "description": ""
           }
         }
-      },
-      "put": {
+      }
+    },
+    "/events/{eventid}/attendees/{userid}": {
+      "get": {
         "tags": [
           "Events"
         ],
@@ -773,19 +810,31 @@
             "type": "string"
           },
           {
-            "name": "body",
-            "in": "body",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "attendeeid": {
-                  "example": "any"
-                },
-                "cancelationMessage": {
-                  "example": "any"
-                }
-              }
-            }
+            "name": "userid",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/events/{eventid}/attendees/registered/length": {
+      "get": {
+        "tags": [
+          "Events"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "eventid",
+            "in": "path",
+            "required": true,
+            "type": "string"
           }
         ],
         "responses": {
@@ -821,6 +870,45 @@
               "type": "object",
               "properties": {
                 "attendeeStatus": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
+    "/events/{eventid}/attendees/{attendeeid}/cancel": {
+      "put": {
+        "tags": [
+          "Events"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "eventid",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "attendeeid",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "cancelationMessage": {
                   "example": "any"
                 }
               }

--- a/backend/prisma/migrations/20250104195833_optional_event_owner/migration.sql
+++ b/backend/prisma/migrations/20250104195833_optional_event_owner/migration.sql
@@ -1,0 +1,8 @@
+-- DropForeignKey
+ALTER TABLE "Event" DROP CONSTRAINT "Event_ownerId_fkey";
+
+-- AlterTable
+ALTER TABLE "Event" ALTER COLUMN "ownerId" DROP NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "Event" ADD CONSTRAINT "Event_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -81,8 +81,8 @@ model Event {
   endDate      DateTime
   mode         EventMode?        @default(IN_PERSON)
   status       EventStatus?      @default(ACTIVE)
-  owner        User              @relation(fields: [ownerId], references: [id], name: "EventOwner")
-  ownerId      String
+  owner        User?             @relation(fields: [ownerId], references: [id], name: "EventOwner")
+  ownerId      String?
   attendees    EventEnrollment[]
   capacity     Int
   tags         EventTags[]

--- a/frontend/src/components/organisms/ManageAttendees.tsx
+++ b/frontend/src/components/organisms/ManageAttendees.tsx
@@ -670,9 +670,11 @@ const ManageAttendees = () => {
     capacity: eventData.capacity,
     image_src: eventData.imageURL,
     tags: eventData.tags,
-    supervisors: [
-      `${eventData.owner?.profile?.firstName} ${eventData.owner?.profile?.lastName}`,
-    ],
+    supervisors: eventData.owner
+      ? [
+          `${eventData.owner?.profile?.firstName} ${eventData.owner?.profile?.lastName}`,
+        ]
+      : ["[deleted user]"],
     description: eventData.description,
     name: eventData.name,
     event_status: eventData.status,

--- a/frontend/src/components/organisms/ProfileForm.tsx
+++ b/frontend/src/components/organisms/ProfileForm.tsx
@@ -111,11 +111,33 @@ const ModalBody = ({
     <div className="space-y-4">
       <div className="font-bold text-2xl text-center">Delete Account</div>
       <div className="mb-12">
-        <div>
+        <p>
           Are you sure you want to delete your account? This change is{" "}
           <b>permanent</b> and there is{" "}
-          <b>no ability to restore your account once it is deleted</b>.
-        </div>
+          <b>no ability to restore your account</b>.
+        </p>
+        {userDetails.role === "VOLUNTEER" && (
+          <p>
+            As a volunteer,{" "}
+            <b>your account details and volunteer history will be deleted</b>.
+            There is no way to recover this data.
+          </p>
+        )}
+        {userDetails.role === "SUPERVISOR" && (
+          <p>
+            As a supervisor, your account details and volunteer history will be
+            deleted. However, <b>events you have created</b> will still remain
+            and can still be managed by other supervisors.
+          </p>
+        )}
+        {userDetails.role === "ADMIN" && (
+          <p>
+            As an admin, make sure that{" "}
+            <b>you have assigned the admin role to at least one other user</b>.
+            Only admins can change the roles of other users. All of your created
+            events will still remain.
+          </p>
+        )}
       </div>
 
       <form onSubmit={handleSubmit(handleDeleteAccount)}>


### PR DESCRIPTION
## Summary

Deleted volunteers have their event history deleted, events created by supervisors/admins stay.
![image](https://github.com/user-attachments/assets/16ded03b-6ae7-4920-810a-ede92191fd4d)

New text in delete account prompt to inform users of this.
![image](https://github.com/user-attachments/assets/64f52954-1f4f-4c61-929a-8db852b91886)

Backend is now protected from deleting users when you are not the same user.
```
{
    "success": false,
    "error": "You are not authorized since your Firebase id does not match the specified userid."
}
```

Closes:
* TODO: deal with deleted users in Manage Attendees
* Deleting volunteers works but deleting supervisors doesn't work when they have already created events
* Delete account is broken (some new firebase error)
* [BUG] Deleting users is not route protected on the server side; volunteers could theoretically delete admins with the right API call...


## Testing

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

## Notes

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->