### PR TITLE
Increase pagination limit for UpcomingEvents

### DIFF
--- a/backend/src/utils/script.ts
+++ b/backend/src/utils/script.ts
@@ -60,7 +60,10 @@ export function createRandomEvent(): dummyEvent {
     (faker.location.buildingNumber, faker.location.city())
   }, ${faker.location.state()}`;
   const startDate = faker.date.soon();
-  const endDate = faker.date.future();
+  const endDate = new Date(startDate);
+  endDate.setHours(
+    startDate.getHours() + faker.number.int({ min: 1, max: 12 })
+  );
   const capacity = faker.number.int({ min: 10, max: 1000 });
   const imageURL = faker.image.urlLoremFlickr({ category: "people" });
   const status = faker.helpers.arrayElement([

--- a/frontend/src/components/organisms/ViewEvents.tsx
+++ b/frontend/src/components/organisms/ViewEvents.tsx
@@ -98,11 +98,12 @@ const UpcomingEvents = ({
     queryKey: ["events"],
     placeholderData: keepPreviousData,
     queryFn: async () => {
+      const limit = 1000;
       // recall this is temp
       const userid = await fetchUserIdFromDatabase(user?.email as string);
       setUserid(userid);
       const upcomingEventsUserRegisteredFor = await api.get(
-        `/events?userid=${userid}&date=upcoming&sort=startDate:asc`
+        `/events?userid=${userid}&date=upcoming&sort=startDate:asc&limit=${limit}`
       );
 
       // Change API call depending on whether supervisor choosese to see all
@@ -110,9 +111,11 @@ const UpcomingEvents = ({
       // console.log(`seeAllEvents ${seeAllEvents}`);
       const upcomingEventsUserSupervises =
         seeAllEvents === true
-          ? await api.get(`/events?date=upcoming&sort=startDate:asc`)
+          ? await api.get(
+              `/events?date=upcoming&sort=startDate:asc&limit=${limit}`
+            )
           : await api.get(
-              `/events?ownerid=${userid}&date=upcoming&sort=startDate:asc`
+              `/events?ownerid=${userid}&date=upcoming&sort=startDate:asc&limit=${limit}`
             );
       return {
         upcomingRegistered: upcomingEventsUserRegisteredFor.data["data"],


### PR DESCRIPTION
## Summary

<!-- Summarize your changes here. -->
Closes:
- [BUG] Upcoming events is paginated to 10 events except there is nothing in the UI to support pagination...

Increased limit to arbitrary 1000 for upcoming events, since theoretically it should never reach that limit.

## Testing

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

## Notes

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->