### PR TITLE
Strengthen backend route protections

### DIFF
--- a/backend/src/events/views.ts
+++ b/backend/src/events/views.ts
@@ -7,7 +7,11 @@ import {
   authIfSupervisorOrAdmin,
   authIfVolunteer,
 } from "../middleware/auth";
-import { attempt, socketNotify } from "../utils/helpers";
+import {
+  attempt,
+  checkUserMatchOrSupervisorAdmin,
+  socketNotify,
+} from "../utils/helpers";
 
 import { errorJson, successJson } from "../utils/jsonResponses";
 import { EventMode, EventStatus, Prisma } from "@prisma/client";
@@ -161,11 +165,13 @@ eventRouter.post(
   useAuth,
   async (req: Request, res: Response) => {
     // #swagger.tags = ['Events']
-    const { attendeeid } = req.body;
-    attempt(res, 200, () =>
-      eventController.addAttendee(req.params.eventid, attendeeid)
-    );
-    socketNotify(`/events/${req.params.eventid}`);
+    checkUserMatchOrSupervisorAdmin(req, res, req.params.userid, async () => {
+      const { attendeeid } = req.body;
+      attempt(res, 200, () =>
+        eventController.addAttendee(req.params.eventid, attendeeid)
+      );
+      socketNotify(`/events/${req.params.eventid}`);
+    });
   }
 );
 
@@ -191,15 +197,17 @@ eventRouter.put(
   useAuth,
   async (req: Request, res: Response) => {
     // #swagger.tags = ['Events']
-    const { cancelationMessage } = req.body;
-    attempt(res, 200, () =>
-      eventController.deleteAttendee(
-        req.params.eventid,
-        req.params.attendeeid,
-        cancelationMessage
-      )
-    );
-    socketNotify(`/events/${req.params.eventid}`);
+    checkUserMatchOrSupervisorAdmin(req, res, req.params.userid, async () => {
+      const { cancelationMessage } = req.body;
+      attempt(res, 200, () =>
+        eventController.deleteAttendee(
+          req.params.eventid,
+          req.params.attendeeid,
+          cancelationMessage
+        )
+      );
+      socketNotify(`/events/${req.params.eventid}`);
+    });
   }
 );
 

--- a/backend/src/events/views.ts
+++ b/backend/src/events/views.ts
@@ -165,8 +165,8 @@ eventRouter.post(
   useAuth,
   async (req: Request, res: Response) => {
     // #swagger.tags = ['Events']
-    checkUserMatchOrSupervisorAdmin(req, res, req.params.userid, async () => {
-      const { attendeeid } = req.body;
+    const { attendeeid } = req.body;
+    checkUserMatchOrSupervisorAdmin(req, res, attendeeid, async () => {
       attempt(res, 200, () =>
         eventController.addAttendee(req.params.eventid, attendeeid)
       );
@@ -197,17 +197,22 @@ eventRouter.put(
   useAuth,
   async (req: Request, res: Response) => {
     // #swagger.tags = ['Events']
-    checkUserMatchOrSupervisorAdmin(req, res, req.params.userid, async () => {
-      const { cancelationMessage } = req.body;
-      attempt(res, 200, () =>
-        eventController.deleteAttendee(
-          req.params.eventid,
-          req.params.attendeeid,
-          cancelationMessage
-        )
-      );
-      socketNotify(`/events/${req.params.eventid}`);
-    });
+    checkUserMatchOrSupervisorAdmin(
+      req,
+      res,
+      req.params.attendeeid,
+      async () => {
+        const { cancelationMessage } = req.body;
+        attempt(res, 200, () =>
+          eventController.deleteAttendee(
+            req.params.eventid,
+            req.params.attendeeid,
+            cancelationMessage
+          )
+        );
+        socketNotify(`/events/${req.params.eventid}`);
+      }
+    );
   }
 );
 

--- a/backend/src/utils/helpers.ts
+++ b/backend/src/utils/helpers.ts
@@ -1,4 +1,4 @@
-import { Request, Response } from "express";
+import { Request, Response, NextFunction } from "express";
 import { errorJson, successJson } from "./jsonResponses";
 import admin from "firebase-admin";
 import { User } from "@prisma/client";
@@ -37,12 +37,17 @@ interface UserRecord {
 
 /**
  * Takes in a userid and returns true if it matches the same user as the current
- * Firebase token.
+ * Firebase token OR if the Firebase token represents a supervisor or admin.
  * @param req - The request
  * @param userId - The user ID from your database
  * @returns A promise that resolves to true if both refer to the same user, otherwise false
  */
-export const checkUserMatch = async (req: Request, userId: string) => {
+export const checkUserMatchOrSupervisorAdmin = async (
+  req: Request,
+  res: Response,
+  userId: string,
+  next: NextFunction
+) => {
   // Get auth token
   if (
     req.headers.authorization &&
@@ -53,10 +58,21 @@ export const checkUserMatch = async (req: Request, userId: string) => {
     const firebaseId = userInfo.uid;
     const firebaseUser = await admin.auth().getUser(firebaseId);
     const user = await userController.getUserByID(userId);
-    return firebaseUser.email === user?.email;
-  } else {
-    return false;
+    if (
+      userInfo.supervisor === true ||
+      userInfo.admin === true ||
+      firebaseUser.email === user?.email
+    ) {
+      return next();
+    }
   }
+
+  // Fall-through case
+  return res.status(500).send({
+    success: false,
+    error:
+      "You are not authorized since your Firebase id does not match the specified userid.",
+  });
 };
 
 /**


### PR DESCRIPTION
## Summary

<!-- Summarize your changes here. -->

Make many PUT and PATCH routes accessible to volunteers only authorized on the backend if the userid or attendeeid matches the user logged in with Firebase.

Closes:
- [SECURITY] I changed it so that volunteers can edit attendee status (so they can cancel events). But theoretically this means they can change the attendee status of other volunteers?
- Added security: use middleware to ensure that the id of the user that requested an update their profile matches the id of the profile their trying to update

## Testing

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

## Notes

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->