### PR TITLE
Clear local storage settings on log out

### DIFF
--- a/frontend/src/components/organisms/NavBar.tsx
+++ b/frontend/src/components/organisms/NavBar.tsx
@@ -12,9 +12,9 @@ const NavBar = () => {
 
   const handleSignOut = async () => {
     try {
+      localStorage.setItem("seeAllEvents", "false"); // clear local storage setting
       await signOutUser();
       queryClient.clear(); // Clear cache for react query
-      localStorage.setItem("seeAllEvents", "false"); // clear local storage setting
       router.replace("/login");
     } catch (error) {
       console.log(error);

--- a/frontend/src/components/organisms/NavBar.tsx
+++ b/frontend/src/components/organisms/NavBar.tsx
@@ -14,6 +14,7 @@ const NavBar = () => {
     try {
       await signOutUser();
       queryClient.clear(); // Clear cache for react query
+      localStorage.setItem("seeAllEvents", "false"); // clear local storage setting
       router.replace("/login");
     } catch (error) {
       console.log(error);


### PR DESCRIPTION
## Summary

Fix: two users on one account error: if you choose "see all events" as an admin then switch to a volunteer account, events will still show up as "see all events"... because it retrieves from local storage

## Testing

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

## Notes

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->