### PR TITLE
Support email enumeration protection in login error handling

### DIFF
--- a/frontend/src/components/organisms/LoginForm.tsx
+++ b/frontend/src/components/organisms/LoginForm.tsx
@@ -88,6 +88,9 @@ const LoginForm = () => {
   useEffect(() => {
     if (signInErrors) {
       switch (signInErrors.code) {
+        case "auth/invalid-credential":
+          setErrorMessage("Invalid email or password.");
+          break;
         case "auth/invalid-email":
           setErrorMessage("Invalid email address format.");
           break;


### PR DESCRIPTION
## Summary

This setting in Firebase changes the error code returned by unsuccessful logins

![image](https://github.com/user-attachments/assets/c8e1f717-cb26-4f35-8293-e98fa505f17f)


## Testing

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

## Notes

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->