### PR TITLE
Fix infinite loading screen on first login

### DIFF
--- a/frontend/src/utils/AuthContext.tsx
+++ b/frontend/src/utils/AuthContext.tsx
@@ -178,7 +178,6 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
       }
 
       if (!user && !publicPaths.includes(path) && !isResetPage(path)) {
-        sessionStorage.setItem("redirectPath", path);
         router.replace("/login");
       } else if (user && user.emailVerified && authPaths.includes(path)) {
         router.replace(


### PR DESCRIPTION
## Summary

1 line change that took FOREVER to fix. this is because router.push happened too many times in production, so the route change would stop and you would always hang on the root URL without redirecting to /events/view. see here

![image](https://github.com/user-attachments/assets/35116733-4b56-4385-ac28-6f4f64f9e667)


and after (note it's less!)
![image](https://github.com/user-attachments/assets/85aa1b50-61fc-498c-ad9b-8d121ecf4f96)


## Testing

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

## Notes

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->