### PR TITLE
Fix event history table showing incorrect attendee status

### DIFF
--- a/frontend/src/components/organisms/ManageUserProfile.tsx
+++ b/frontend/src/components/organisms/ManageUserProfile.tsx
@@ -383,10 +383,15 @@ const ManageUserProfile = () => {
   const registeredEvents: eventRegistrationData[] = [];
   const totalNumberofData = data?.totalItems || 0;
   data?.result.map((event: any) => {
+    // Filter event attendees to only show the userid we are looking for
+    let attendeesFiltered = event.attendees.filter(
+      (attendee: any) => attendee["userId"] === userid
+    );
+
     let attendeeStatus =
-      event.attendees.length > 0
+      attendeesFiltered.length > 0
         ? convertEnrollmentStatusToString(
-            event.attendees["0"]["attendeeStatus"]
+            attendeesFiltered["0"]["attendeeStatus"]
           )
         : undefined;
 

--- a/frontend/src/utils/useViewEventState.ts
+++ b/frontend/src/utils/useViewEventState.ts
@@ -93,10 +93,15 @@ function useViewEventState(
   const rows: any[] = [];
   const totalNumberofData = data?.data.totalItems;
   data?.data.result.map((event: any) => {
+    // Filter event attendees to only show the userid we are looking for
+    let attendeesFiltered = event.attendees.filter(
+      (attendee: any) => attendee["userId"] === userid
+    );
+
     let attendeeStatus =
-      event.attendees.length > 0
+      attendeesFiltered.length > 0
         ? convertEnrollmentStatusToString(
-            event.attendees["0"]["attendeeStatus"]
+            attendeesFiltered["0"]["attendeeStatus"]
           )
         : undefined;
 


### PR DESCRIPTION
## Summary

Event History table in Manage User Profile and Past Events used to only grab the attendee status from the first attendee in the event, not correctly filtering for userid