### PR TITLE
Change hour tracking to new format

### DIFF
--- a/backend/api-spec.json
+++ b/backend/api-spec.json
@@ -346,6 +346,39 @@
         }
       }
     },
+    "/users/{userid}/legacyHours": {
+      "patch": {
+        "tags": [
+          "Users"
+        ],
+        "description": "",
+        "parameters": [
+          {
+            "name": "userid",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "legacyHours": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": ""
+          }
+        }
+      }
+    },
     "/users/{userid}/role": {
       "patch": {
         "tags": [

--- a/backend/prisma/migrations/20250515224753_change_hours/migration.sql
+++ b/backend/prisma/migrations/20250515224753_change_hours/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Event" ADD COLUMN     "hours" INTEGER NOT NULL DEFAULT 0;
+
+-- AlterTable
+ALTER TABLE "EventEnrollment" ADD COLUMN     "customHours" INTEGER;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -68,6 +68,7 @@ model Event {
   ownerId      String?
   attendees    EventEnrollment[]
   capacity     Int
+  hours        Int               @default(0)
 }
 
 model EventEnrollment {
@@ -82,6 +83,7 @@ model EventEnrollment {
   user               User             @relation(fields: [userId], references: [id], onDelete: Cascade)
   cancelationMessage String?
   attendeeStatus     EnrollmentStatus @default(PENDING)
+  customHours        Int?
 
   @@id([userId, eventId])
 }

--- a/backend/src/events/controllers.ts
+++ b/backend/src/events/controllers.ts
@@ -362,7 +362,8 @@ export const getRegisteredVolunteerNumberInEvent = async (eventid: string) => {
 const updateEnrollmentStatus = async (
   eventID: string,
   userID: string,
-  newStatus: EnrollmentStatus
+  newStatus: EnrollmentStatus,
+  customHours: number | null
 ) => {
   return await prisma.eventEnrollment.update({
     where: {
@@ -373,6 +374,7 @@ const updateEnrollmentStatus = async (
     },
     data: {
       attendeeStatus: newStatus,
+      customHours: customHours,
     },
   });
 };

--- a/backend/src/events/views.ts
+++ b/backend/src/events/views.ts
@@ -155,12 +155,13 @@ eventRouter.patch(
   useSupervisorAdminAuth,
   async (req: Request, res: Response) => {
     // #swagger.tags = ['Events']
-    const { attendeeStatus } = req.body;
+    const { attendeeStatus, customHours } = req.body;
     attempt(res, 200, () =>
       eventController.updateEnrollmentStatus(
         req.params.eventid,
         req.params.userid,
-        attendeeStatus
+        attendeeStatus,
+        customHours
       )
     );
     socketNotify(`/events/${req.params.eventid}`);

--- a/frontend/src/components/organisms/EventForm.tsx
+++ b/frontend/src/components/organisms/EventForm.tsx
@@ -40,6 +40,7 @@ type FormValues = {
   location: string;
   locationLink: string;
   volunteerSignUpCap: string;
+  defaultHoursAwarded: string;
   eventDescription: string;
   imageURL: string;
   rsvpLinkImage: string;
@@ -110,6 +111,7 @@ const EventForm = ({
             location: eventDetails.location,
             locationLink: eventDetails.locationLink,
             volunteerSignUpCap: eventDetails.volunteerSignUpCap,
+            defaultHoursAwarded: eventDetails.defaultHoursAwarded,
             eventDescription: eventDetails.eventDescription,
             imageURL: eventDetails.imageURL,
             rsvpLinkImage: eventDetails.rsvpLinkImage,
@@ -143,6 +145,7 @@ const EventForm = ({
         location,
         locationLink,
         volunteerSignUpCap,
+        defaultHoursAwarded,
         eventDescription,
         imageURL,
         startDate,
@@ -168,6 +171,7 @@ const EventForm = ({
           startDate: startDateTime,
           endDate: endDateTime,
           capacity: +volunteerSignUpCap,
+          hours: +defaultHoursAwarded,
           mode: `${mode}`,
         },
       });
@@ -190,6 +194,7 @@ const EventForm = ({
           location,
           locationLink,
           volunteerSignUpCap,
+          defaultHoursAwarded,
           eventDescription,
           imageURL,
           startDate,
@@ -219,6 +224,7 @@ const EventForm = ({
           startDate: startDateTime,
           endDate: endDateTime,
           capacity: +volunteerSignUpCap,
+          hours: +defaultHoursAwarded,
           mode: `${mode}`,
         });
         return response;
@@ -465,7 +471,7 @@ const EventForm = ({
           </FormControl>
           <div>
             {status == 1 ? (
-              <div className="grid grid-cols-1 sm:grid-cols-2 col-span-2 sm:col-span-1 space-x-0 sm:space-x-4">
+              <div className="grid grid-cols-1 sm:grid-cols-2 col-span-2 sm:col-span-1 space-x-0 sm:gap-4">
                 <TextField
                   placeholder="Label for location"
                   error={errors.location?.message}
@@ -485,7 +491,7 @@ const EventForm = ({
                 />
               </div>
             ) : (
-              <div className="grid grid-cols-1 sm:grid-cols-2 col-span-2 sm:col-span-1 space-x-0 sm:space-x-4">
+              <div className="grid grid-cols-1 sm:grid-cols-2 col-span-2 sm:col-span-1 space-x-0 sm:gap-4">
                 <TextField
                   disabled
                   value="VIRTUAL"
@@ -509,11 +515,22 @@ const EventForm = ({
             )}
           </div>
         </div>
-        <div className="grid grid-cols-1 sm:grid-cols-2 col-span-2  sm:col-span-1">
+        <div className="grid grid-cols-1 sm:grid-cols-2 col-span-2 sm:col-span-1 gap-4">
           <TextField
             label="Maximum Number of Volunteers"
             error={errors.volunteerSignUpCap?.message}
             {...register("volunteerSignUpCap", {
+              required: { value: true, message: "Required " },
+              pattern: {
+                value: /^\d+$/i,
+                message: "Invalid number",
+              },
+            })}
+          />
+          <TextField
+            label="Default Hours Awarded"
+            error={errors.defaultHoursAwarded?.message}
+            {...register("defaultHoursAwarded", {
               required: { value: true, message: "Required " },
               pattern: {
                 value: /^\d+$/i,

--- a/frontend/src/components/organisms/ManageAttendees.tsx
+++ b/frontend/src/components/organisms/ManageAttendees.tsx
@@ -10,6 +10,7 @@ import Modal from "@/components/molecules/Modal";
 import { useForm, SubmitHandler, Controller } from "react-hook-form";
 import { MenuItem, Grid } from "@mui/material";
 import FileCopyIcon from "@mui/icons-material/FileCopy";
+import HourglassBottomIcon from "@mui/icons-material/HourglassBottom";
 import SearchBar from "../atoms/SearchBar";
 import Button from "../atoms/Button";
 import Select from "../atoms/Select";
@@ -666,6 +667,7 @@ const ManageAttendees = () => {
     locationLink,
     datetime,
     capacity,
+    hours,
     image_src,
     tags,
     supervisors,
@@ -678,6 +680,7 @@ const ManageAttendees = () => {
     locationLink: eventData.locationLink,
     datetime: formatDateTimeRange(eventData.startDate, eventData.endDate),
     capacity: eventData.capacity,
+    hours: eventData.hours,
     image_src: eventData.imageURL,
     tags: eventData.tags,
     supervisors: eventData.owner
@@ -947,6 +950,11 @@ const ManageAttendees = () => {
                 {registeredVolunteersNumber}/{capacity} volunteers registered
               </>
             }
+          />
+          <IconTextHeader
+            icon={<HourglassBottomIcon />}
+            header={<>Volunteer Hours</>}
+            body={<>{hours} hours</>}
           />
           <TextCopy
             label="RSVP Link"

--- a/frontend/src/components/organisms/ManageAttendees.tsx
+++ b/frontend/src/components/organisms/ManageAttendees.tsx
@@ -8,7 +8,7 @@ import {
 import Table from "@/components/molecules/Table";
 import Modal from "@/components/molecules/Modal";
 import { useForm, SubmitHandler, Controller } from "react-hook-form";
-import { MenuItem, Grid } from "@mui/material";
+import { MenuItem, Grid, Tooltip } from "@mui/material";
 import FileCopyIcon from "@mui/icons-material/FileCopy";
 import HourglassBottomIcon from "@mui/icons-material/HourglassBottom";
 import SearchBar from "../atoms/SearchBar";
@@ -45,6 +45,7 @@ import Alert from "../atoms/Alert";
 import Loading from "../molecules/Loading";
 import Switch from "@mui/material/Switch";
 import TextField from "../atoms/TextField";
+import InfoOutlineIcon from "@mui/icons-material/InfoOutlined";
 
 type attendeeData = {
   id: number;
@@ -229,6 +230,21 @@ const AttendeesTable = ({
       flex: 0.5,
       renderHeader: (params) => (
         <div style={{ fontWeight: "bold" }}>{params.colDef.headerName}</div>
+      ),
+    },
+    {
+      field: "customHours",
+      headerName: "Awarded hours",
+      sortable: false,
+      minWidth: 150,
+      flex: 0.5,
+      renderHeader: (params) => (
+        <div className="flex flex-row items-center gap-1">
+          <div style={{ fontWeight: "bold" }}>{params.colDef.headerName}</div>
+          <Tooltip title="Awarded hours are the actual number of hours you receive for participating in the event. This may be different from the default hours if a supervisor manually changes the hours you were awarded.">
+            <InfoOutlineIcon fontSize="small" />
+          </Tooltip>
+        </div>
       ),
     },
     {
@@ -763,66 +779,6 @@ const ManageAttendees = () => {
   const router = useRouter();
   const eventid = router.query.eventid as string;
 
-  const {
-    rows: pendingUsers,
-    isPending: pendingUsersIsPending,
-    error: pendingUsersError,
-    paginationModel: pendingUsersPaginationModel,
-    sortModel: pendingUsersSortModel,
-    handlePaginationModelChange: handlePendingUsersPaginationModelChange,
-    handleSortModelChange: handlePendingUsersSortModelChange,
-    handleSearchQuery: handlePendingUsersSearchQuery,
-    totalNumberofData: totalNumberofPendingUsers,
-  } = useManageAttendeeState("PENDING", eventid);
-
-  const {
-    rows: checkedInUsers,
-    isPending: checkedInUsersIsPending,
-    error: checkedInUsersError,
-    paginationModel: checkedInUsersPaginationModel,
-    sortModel: checkedInUsersSortModel,
-    handlePaginationModelChange: handleCheckedInUsersPaginationModelChange,
-    handleSortModelChange: handleCheckedInUsersSortModelChange,
-    handleSearchQuery: handleCheckedInUsersSearchQuery,
-    totalNumberofData: totalNumberofCheckedInUsers,
-  } = useManageAttendeeState("CHECKED_IN", eventid);
-
-  const {
-    rows: checkedOutUsers,
-    isPending: checkedOutUsersIsPending,
-    error: checkedOutUsersError,
-    paginationModel: checkedOutUsersPaginationModel,
-    sortModel: checkedOutUsersSortModel,
-    handlePaginationModelChange: handleCheckedOutUsersPaginationModelChange,
-    handleSortModelChange: handleCheckedOutUsersSortModelChange,
-    handleSearchQuery: handleCheckedOutUsersSearchQuery,
-    totalNumberofData: totalNumberofCheckedOutUsers,
-  } = useManageAttendeeState("CHECKED_OUT", eventid);
-
-  const {
-    rows: canceledUsers,
-    isPending: canceledUsersIsPending,
-    error: canceledUsersError,
-    paginationModel: canceledUsersPaginationModel,
-    sortModel: canceledUsersSortModel,
-    handlePaginationModelChange: handleCanceledUsersPaginationModelChange,
-    handleSortModelChange: handleCanceledUsersSortModelChange,
-    handleSearchQuery: handleCanceledUsersSearchQuery,
-    totalNumberofData: totalNumberofCanceledUsers,
-  } = useManageAttendeeState("CANCELED", eventid);
-
-  const {
-    rows: removedUsers,
-    isPending: removedUsersIsPending,
-    error: removedUsersError,
-    paginationModel: removedUsersPaginationModel,
-    sortModel: removedUsersSortModel,
-    handlePaginationModelChange: handleRemovedUsersPaginationModelChange,
-    handleSortModelChange: handleRemovedUsersSortModelChange,
-    handleSearchQuery: handleRemovedUsersSearchQuery,
-    totalNumberofData: totalNumberofRemovedUsers,
-  } = useManageAttendeeState("REMOVED", eventid);
-
   const { user, role } = useAuth();
   const [userid, setUserid] = React.useState("");
 
@@ -887,6 +843,66 @@ const ManageAttendees = () => {
 
   /** Whether checking a volunteer out should prompt for using a custom set of hours */
   const [useCustomHours, setUseCustomHours] = useState(false);
+
+  const {
+    rows: pendingUsers,
+    isPending: pendingUsersIsPending,
+    error: pendingUsersError,
+    paginationModel: pendingUsersPaginationModel,
+    sortModel: pendingUsersSortModel,
+    handlePaginationModelChange: handlePendingUsersPaginationModelChange,
+    handleSortModelChange: handlePendingUsersSortModelChange,
+    handleSearchQuery: handlePendingUsersSearchQuery,
+    totalNumberofData: totalNumberofPendingUsers,
+  } = useManageAttendeeState("PENDING", eventid, eventData.hours);
+
+  const {
+    rows: checkedInUsers,
+    isPending: checkedInUsersIsPending,
+    error: checkedInUsersError,
+    paginationModel: checkedInUsersPaginationModel,
+    sortModel: checkedInUsersSortModel,
+    handlePaginationModelChange: handleCheckedInUsersPaginationModelChange,
+    handleSortModelChange: handleCheckedInUsersSortModelChange,
+    handleSearchQuery: handleCheckedInUsersSearchQuery,
+    totalNumberofData: totalNumberofCheckedInUsers,
+  } = useManageAttendeeState("CHECKED_IN", eventid, eventData.hours);
+
+  const {
+    rows: checkedOutUsers,
+    isPending: checkedOutUsersIsPending,
+    error: checkedOutUsersError,
+    paginationModel: checkedOutUsersPaginationModel,
+    sortModel: checkedOutUsersSortModel,
+    handlePaginationModelChange: handleCheckedOutUsersPaginationModelChange,
+    handleSortModelChange: handleCheckedOutUsersSortModelChange,
+    handleSearchQuery: handleCheckedOutUsersSearchQuery,
+    totalNumberofData: totalNumberofCheckedOutUsers,
+  } = useManageAttendeeState("CHECKED_OUT", eventid, eventData.hours);
+
+  const {
+    rows: canceledUsers,
+    isPending: canceledUsersIsPending,
+    error: canceledUsersError,
+    paginationModel: canceledUsersPaginationModel,
+    sortModel: canceledUsersSortModel,
+    handlePaginationModelChange: handleCanceledUsersPaginationModelChange,
+    handleSortModelChange: handleCanceledUsersSortModelChange,
+    handleSearchQuery: handleCanceledUsersSearchQuery,
+    totalNumberofData: totalNumberofCanceledUsers,
+  } = useManageAttendeeState("CANCELED", eventid, eventData.hours);
+
+  const {
+    rows: removedUsers,
+    isPending: removedUsersIsPending,
+    error: removedUsersError,
+    paginationModel: removedUsersPaginationModel,
+    sortModel: removedUsersSortModel,
+    handlePaginationModelChange: handleRemovedUsersPaginationModelChange,
+    handleSortModelChange: handleRemovedUsersSortModelChange,
+    handleSearchQuery: handleRemovedUsersSearchQuery,
+    totalNumberofData: totalNumberofRemovedUsers,
+  } = useManageAttendeeState("REMOVED", eventid, eventData.hours);
 
   /** Attendees list tabs */
   const tabs = [

--- a/frontend/src/components/organisms/ManageUserProfile.tsx
+++ b/frontend/src/components/organisms/ManageUserProfile.tsx
@@ -27,7 +27,7 @@ import {
 import { useRouter } from "next/router";
 import Loading from "../molecules/Loading";
 import { SelectChangeEvent } from "@mui/material/Select";
-import { Box, Grid } from "@mui/material";
+import { Box, Grid, Tooltip } from "@mui/material";
 import Modal from "../molecules/Modal";
 import Snackbar from "../atoms/Snackbar";
 import { formatRoleOrStatus } from "@/utils/helpers";
@@ -37,6 +37,7 @@ import ArrowOutwardIcon from "@mui/icons-material/ArrowOutward";
 import Chip from "../atoms/Chip";
 import { SubmitHandler, useForm } from "react-hook-form";
 import TextField from "../atoms/TextField";
+import InfoOutlineIcon from "@mui/icons-material/InfoOutlined";
 
 type userProfileData = {
   name: string;
@@ -54,6 +55,7 @@ type eventRegistrationData = {
   id: string;
   name: string;
   startDate: string;
+  standardHours: string;
   hours: string;
   status: string;
   attendeeStatus?: string;
@@ -90,13 +92,35 @@ const eventColumns: GridColDef[] = [
     ),
   },
   {
-    field: "hours",
-    headerName: "Hours",
+    field: "standardHours",
+    headerName: "Default hours",
     sortable: false,
     type: "string",
     flex: 0.5,
+    minWidth: 150,
     renderHeader: (params) => (
-      <div style={{ fontWeight: "bold" }}>{params.colDef.headerName}</div>
+      <div className="flex flex-row items-center gap-1">
+        <div style={{ fontWeight: "bold" }}>{params.colDef.headerName}</div>
+        <Tooltip title="Default hours is the default number of hours awarded to each volunteer that is checked out of the event. This number is hidden if it is the same as your awarded hours.">
+          <InfoOutlineIcon fontSize="small" />
+        </Tooltip>
+      </div>
+    ),
+  },
+  {
+    field: "hours",
+    headerName: "Awarded hours",
+    sortable: false,
+    type: "string",
+    flex: 0.5,
+    minWidth: 150,
+    renderHeader: (params) => (
+      <div className="flex flex-row items-center gap-1">
+        <div style={{ fontWeight: "bold" }}>{params.colDef.headerName}</div>
+        <Tooltip title="Awarded hours are the actual number of hours you receive for participating in the event. This may be different from the default hours if a supervisor manually changes the hours you were awarded.">
+          <InfoOutlineIcon fontSize="small" />
+        </Tooltip>
+      </div>
     ),
   },
   {
@@ -396,16 +420,21 @@ const ManageUserProfile = () => {
         : undefined;
 
     // Get number of hours awarded to this event enrollment
-    let awardedHours =
+    let hasCustomHours =
       attendeesFiltered.length > 0 &&
-      attendeesFiltered["0"]["customHours"] !== null
-        ? attendeesFiltered["0"]["customHours"]
-        : event.hours;
+      attendeesFiltered["0"]["customHours"] !== null;
+    let awardedHours = hasCustomHours
+      ? attendeesFiltered["0"]["customHours"]
+      : event.hours;
 
     registeredEvents.push({
       id: event.id,
       name: event.name,
       startDate: formatDateString(event.startDate),
+      standardHours:
+        hasCustomHours || attendeeStatus !== "Checked out"
+          ? friendlyHours(event.hours)
+          : "",
       hours:
         attendeeStatus === "Checked out" ? friendlyHours(awardedHours) : "N/A",
       status: event.status,

--- a/frontend/src/components/organisms/ManageUserProfile.tsx
+++ b/frontend/src/components/organisms/ManageUserProfile.tsx
@@ -395,14 +395,19 @@ const ManageUserProfile = () => {
           )
         : undefined;
 
+    // Get number of hours awarded to this event enrollment
+    let awardedHours =
+      attendeesFiltered.length > 0 &&
+      attendeesFiltered["0"]["customHours"] !== null
+        ? attendeesFiltered["0"]["customHours"]
+        : event.hours;
+
     registeredEvents.push({
       id: event.id,
       name: event.name,
       startDate: formatDateString(event.startDate),
       hours:
-        attendeeStatus === "Checked out"
-          ? eventHours(event.endDate, event.startDate)
-          : "N/A",
+        attendeeStatus === "Checked out" ? friendlyHours(awardedHours) : "N/A",
       status: event.status,
       attendeeStatus: attendeeStatus,
     });

--- a/frontend/src/components/organisms/ViewEventDetails.tsx
+++ b/frontend/src/components/organisms/ViewEventDetails.tsx
@@ -3,7 +3,7 @@ import EventTemplate from "../templates/EventTemplate";
 import EventCardRegister from "./EventCardRegister";
 import Divider from "@mui/material/Divider";
 import IconTextHeader from "../atoms/IconTextHeader";
-import LocationOnIcon from "@mui/icons-material/LocationOn";
+import HourglassBottomIcon from "@mui/icons-material/HourglassBottom";
 import Link from "next/link";
 import CalendarTodayIcon from "@mui/icons-material/CalendarToday";
 import PersonIcon from "@mui/icons-material/Person";
@@ -112,6 +112,7 @@ const ViewEventDetails = () => {
     locationLink,
     datetime,
     capacity,
+    hours,
     image_src,
     tags,
     supervisors,
@@ -124,6 +125,7 @@ const ViewEventDetails = () => {
     locationLink: eventData.locationLink,
     datetime: formatDateTimeRange(eventData.startDate, eventData.endDate),
     capacity: eventData.capacity,
+    hours: eventData.hours,
     image_src: eventData.imageURL,
     tags: eventData.tags,
     supervisors: [
@@ -207,6 +209,11 @@ const ViewEventDetails = () => {
                   {registeredVolunteersNumber}/{capacity} volunteers registered
                 </>
               }
+            />
+            <IconTextHeader
+              icon={<HourglassBottomIcon />}
+              header={<>Volunteer Hours</>}
+              body={<>{hours} hours</>}
             />
           </div>
         </div>

--- a/frontend/src/components/organisms/ViewEvents.tsx
+++ b/frontend/src/components/organisms/ViewEvents.tsx
@@ -15,7 +15,8 @@ import {
 } from "@/utils/helpers";
 import { Action, ViewEventsEvent } from "@/utils/types";
 import Select from "../atoms/Select";
-import { MenuItem } from "@mui/material";
+import { MenuItem, Tooltip } from "@mui/material";
+import InfoOutlineIcon from "@mui/icons-material/InfoOutlined";
 import { api } from "@/utils/api";
 import ManageSearchIcon from "@mui/icons-material/ManageSearch";
 import {
@@ -276,12 +277,35 @@ const PastEvents = ({
       ),
     },
     {
-      field: "hours",
-      headerName: "Hours",
+      field: "standardHours",
+      headerName: "Default hours",
       sortable: false,
+      type: "string",
       flex: 0.5,
+      minWidth: 150,
       renderHeader: (params) => (
-        <div style={{ fontWeight: "bold" }}>{params.colDef.headerName}</div>
+        <div className="flex flex-row items-center gap-1">
+          <div style={{ fontWeight: "bold" }}>{params.colDef.headerName}</div>
+          <Tooltip title="Default hours is the default number of hours awarded to each volunteer that is checked out of the event. This number is hidden if it is the same as your awarded hours.">
+            <InfoOutlineIcon fontSize="small" />
+          </Tooltip>
+        </div>
+      ),
+    },
+    {
+      field: "hours",
+      headerName: "Awarded hours",
+      sortable: false,
+      type: "string",
+      flex: 0.5,
+      minWidth: 150,
+      renderHeader: (params) => (
+        <div className="flex flex-row items-center gap-1">
+          <div style={{ fontWeight: "bold" }}>{params.colDef.headerName}</div>
+          <Tooltip title="Awarded hours are the actual number of hours you receive for participating in the event. This may be different from the default hours if a supervisor manually changes the hours you were awarded.">
+            <InfoOutlineIcon fontSize="small" />
+          </Tooltip>
+        </div>
       ),
     },
     {

--- a/frontend/src/pages/events/[eventid]/edit.tsx
+++ b/frontend/src/pages/events/[eventid]/edit.tsx
@@ -14,6 +14,7 @@ type eventData = {
   location: string;
   locationLink: string;
   volunteerSignUpCap: string;
+  defaultHoursAwarded: string;
   eventDescription: string;
   imageURL: string;
   rsvpLinkImage: string;
@@ -44,6 +45,7 @@ const EditEvent = () => {
     location: data?.location,
     locationLink: data?.locationLink,
     volunteerSignUpCap: data?.capacity,
+    defaultHoursAwarded: data?.hours,
     eventDescription: data?.description,
     imageURL: data?.imageURL || "",
     rsvpLinkImage: data?.rsvpLinkImage || "",

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -23,6 +23,7 @@ export type EventData = {
   datetime: string;
   supervisors: string[];
   capacity: number;
+  hours: number;
   image_src: string;
   tags: string[] | undefined;
   description: string;

--- a/frontend/src/utils/useViewEventState.ts
+++ b/frontend/src/utils/useViewEventState.ts
@@ -8,6 +8,7 @@ import { api } from "./api";
 import {
   convertEnrollmentStatusToString,
   formatRoleOrStatus,
+  friendlyHours,
 } from "@/utils/helpers";
 import { GridPaginationModel, GridSortModel } from "@mui/x-data-grid";
 import { eventHours } from "@/utils/helpers";
@@ -105,6 +106,13 @@ function useViewEventState(
           )
         : undefined;
 
+    // Get number of hours awarded to this event enrollment
+    let awardedHours =
+      attendeesFiltered.length > 0 &&
+      attendeesFiltered["0"]["customHours"] !== null
+        ? attendeesFiltered["0"]["customHours"]
+        : event.hours;
+
     rows.push({
       id: event.id,
       name: event.name,
@@ -113,9 +121,7 @@ function useViewEventState(
       endDate: new Date(event.endDate),
       role: event.role,
       hours:
-        attendeeStatus === "Checked out"
-          ? eventHours(event.endDate, event.startDate)
-          : "N/A",
+        attendeeStatus === "Checked out" ? friendlyHours(awardedHours) : "N/A",
       status: event.status,
       attendeeStatus: attendeeStatus,
     });

--- a/frontend/src/utils/useViewEventState.ts
+++ b/frontend/src/utils/useViewEventState.ts
@@ -107,11 +107,12 @@ function useViewEventState(
         : undefined;
 
     // Get number of hours awarded to this event enrollment
-    let awardedHours =
+    let hasCustomHours =
       attendeesFiltered.length > 0 &&
-      attendeesFiltered["0"]["customHours"] !== null
-        ? attendeesFiltered["0"]["customHours"]
-        : event.hours;
+      attendeesFiltered["0"]["customHours"] !== null;
+    let awardedHours = hasCustomHours
+      ? attendeesFiltered["0"]["customHours"]
+      : event.hours;
 
     rows.push({
       id: event.id,
@@ -120,6 +121,10 @@ function useViewEventState(
       startDate: formatDateString(event.startDate),
       endDate: new Date(event.endDate),
       role: event.role,
+      standardHours:
+        hasCustomHours || attendeeStatus !== "Checked out"
+          ? friendlyHours(event.hours)
+          : "",
       hours:
         attendeeStatus === "Checked out" ? friendlyHours(awardedHours) : "N/A",
       status: event.status,


### PR DESCRIPTION
## Summary

Resolved: in create / edit event, include a text field that says how many hours a volunteer should get for the event (say 4 hours), and all volunteers that are checked out would get that number of hours. then, in the manage attendees tab, there is a new option in addition to check out called "custom check out", which when clicked, a modal would pop up that includes the custom number of hours that the volunteer should have.

![image](https://github.com/user-attachments/assets/6c464a8f-92b5-4286-9749-614885a6d99f)

![image](https://github.com/user-attachments/assets/b451c861-391f-499d-8ee5-c0a63e77f4ac)

![image](https://github.com/user-attachments/assets/f189f83e-a771-417d-8009-84d3dccd6426)
