### PR TITLE
Improve clarity for event register card

### DIFF
--- a/frontend/src/components/organisms/EventCardRegister.tsx
+++ b/frontend/src/components/organisms/EventCardRegister.tsx
@@ -53,44 +53,93 @@ const EventCardRegister = ({
   const currentDate = new Date();
   const eventInPast = date < currentDate;
 
-  return (
-    <Card>
-      <div className="font-semibold text-2xl">Register for this event</div>
-      <div className="mt-5" />
-      <div className="font-semibold">Terms and conditions</div>
-      <div>
-        By registering, I commit to attending the event. If I'm unable to
-        participate, I will cancel my registration at least 24 hours before the
-        event starts. Failure to do so may affect my volunteer status.
-      </div>
-      <div className="mt-3" />
-      <CustomCheckbox
-        label="I agree to the terms and conditions"
-        disabled={
-          attendeeBlacklisted || eventCanceled || eventInPast || overCapacity
-        }
-        onChange={() => setIsChecked(!isChecked)}
-      />
-      <div className="mt-3" />
-      {attendeeBlacklisted ? (
-        <Button disabled>You have been blacklisted.</Button>
-      ) : eventCanceled ? (
-        <Button disabled>The event has been canceled.</Button>
-      ) : eventInPast ? (
-        <Button disabled>The event has concluded.</Button>
-      ) : overCapacity ? (
-        <Button disabled>The event has reached capacity.</Button>
-      ) : (
-        <Button
-          onClick={handleEventResgistration}
-          disabled={!isChecked}
-          loading={isPending}
-        >
-          Register
-        </Button>
-      )}
-    </Card>
-  );
+  // If volunteer has been blacklisted
+  if (attendeeBlacklisted) {
+    return (
+      <Card>
+        <div className="font-semibold text-2xl">Register for this event</div>
+        <div className="my-5">
+          Unfortunately, you have been blacklisted by a supervisor. You are no
+          longer able to register for any event.
+        </div>
+        <Button disabled>You have been blacklisted</Button>
+      </Card>
+    );
+  }
+
+  // If the event has been canceled
+  else if (eventCanceled) {
+    return (
+      <Card>
+        <div className="font-semibold text-2xl">Register for this event</div>
+        <div className="my-5">
+          Unfortunately, the event has been canceled. You are no longer able to
+          register.
+        </div>
+        <Button disabled>The event has been canceled</Button>
+      </Card>
+    );
+  }
+
+  // If the event has been concluded
+  else if (eventInPast) {
+    return (
+      <Card>
+        <div className="font-semibold text-2xl">Register for this event</div>
+        <div className="my-5">
+          Unfortunately, the event has concluded. You are no longer able to
+          register.
+        </div>
+        <Button disabled>The event has concluded</Button>
+      </Card>
+    );
+  }
+
+  // If the event is over capacity
+  else if (overCapacity) {
+    return (
+      <Card>
+        <div className="font-semibold text-2xl">Register for this event</div>
+        <div className="my-5">
+          Unfortunately, the event has reached capacity. You are no longer able
+          to register.
+        </div>
+        <Button disabled>The event has reached capacity</Button>
+      </Card>
+    );
+  }
+
+  // If the vollunteer is eligible to register for the event
+  else {
+    return (
+      <Card>
+        <div className="font-semibold text-2xl mb-5">
+          Register for this event
+        </div>
+        <div>
+          <div className="font-semibold mb-3">Terms and conditions</div>
+          <div className="mb-3">
+            By registering, I commit to attending the event. If I'm unable to
+            participate, I will cancel my registration at least 24 hours before
+            the event starts. Failure to do so may affect my volunteer status.
+          </div>
+          <CustomCheckbox
+            label="I agree to the terms and conditions"
+            onChange={() => setIsChecked(!isChecked)}
+          />
+          <div className="mt-3">
+            <Button
+              onClick={handleEventResgistration}
+              disabled={!isChecked}
+              loading={isPending}
+            >
+              Register
+            </Button>
+          </div>
+        </div>
+      </Card>
+    );
+  }
 };
 
 export default EventCardRegister;

--- a/frontend/src/components/organisms/EventCardRegister.tsx
+++ b/frontend/src/components/organisms/EventCardRegister.tsx
@@ -109,7 +109,7 @@ const EventCardRegister = ({
     );
   }
 
-  // If the vollunteer is eligible to register for the event
+  // If the volunteer is eligible to register for the event
   else {
     return (
       <Card>


### PR DESCRIPTION
## Summary

Closes: add to event register card, change the terms and conditions text to be "unfortunately the event has reached capacity." probably do the same with past events where "this event has concluded" (even though LFBI only asked for "this event has reached capacity"

![image](https://github.com/user-attachments/assets/4d7e851a-cad2-4b4b-a305-0479c6f22632)
![image](https://github.com/user-attachments/assets/52b6fb90-ed0c-4799-ab66-a93cbdfa6189)
![image](https://github.com/user-attachments/assets/d1609a7c-a1f7-4f3d-9d4b-e74c3fe9b599)
![image](https://github.com/user-attachments/assets/07dbd8d8-1512-4603-b05a-3c0f541d3ebf)
![image](https://github.com/user-attachments/assets/f7959da4-de9d-49f6-9875-feafde2fd7ec)
