### PR TITLE
Allow event edits and registrations before event concludes

### DIFF
--- a/frontend/src/components/organisms/EventCardRegister.tsx
+++ b/frontend/src/components/organisms/EventCardRegister.tsx
@@ -59,8 +59,8 @@ const EventCardRegister = ({
       <Card>
         <div className="font-semibold text-2xl">Register for this event</div>
         <div className="my-5">
-          Unfortunately, you have been blacklisted by a supervisor. You are no
-          longer able to register for any event.
+          You have been blacklisted. You are no longer able to register for any
+          event.
         </div>
         <Button disabled>You have been blacklisted</Button>
       </Card>
@@ -73,8 +73,7 @@ const EventCardRegister = ({
       <Card>
         <div className="font-semibold text-2xl">Register for this event</div>
         <div className="my-5">
-          Unfortunately, the event has been canceled. You are no longer able to
-          register.
+          The event has been canceled. You are no longer able to register.
         </div>
         <Button disabled>The event has been canceled</Button>
       </Card>
@@ -87,8 +86,7 @@ const EventCardRegister = ({
       <Card>
         <div className="font-semibold text-2xl">Register for this event</div>
         <div className="my-5">
-          Unfortunately, the event has concluded. You are no longer able to
-          register.
+          The event has concluded. You are no longer able to register.
         </div>
         <Button disabled>The event has concluded</Button>
       </Card>
@@ -101,8 +99,7 @@ const EventCardRegister = ({
       <Card>
         <div className="font-semibold text-2xl">Register for this event</div>
         <div className="my-5">
-          Unfortunately, the event has reached capacity. You are no longer able
-          to register.
+          The event has reached capacity. You are no longer able to register.
         </div>
         <Button disabled>The event has reached capacity</Button>
       </Card>

--- a/frontend/src/components/organisms/EventForm.tsx
+++ b/frontend/src/components/organisms/EventForm.tsx
@@ -27,14 +27,15 @@ import Dropzone from "../atoms/Dropzone";
 import Alert from "../atoms/Alert";
 import EditorComp from "@/components/atoms/Editor";
 import Modal from "../molecules/Modal";
+import dayjs from "dayjs";
 
 interface EventFormProps {
   eventId?: string | string[] | undefined;
   eventType: string; //"create" | "edit"
-  eventDetails?: FormValues;
+  eventDetails?: EventDetailsProp;
 }
 
-type FormValues = {
+type EventDetailsProp = {
   id: string;
   eventName: string;
   location: string;
@@ -47,6 +48,23 @@ type FormValues = {
   startDate: string;
   startTime: string;
   endTime: string;
+  mode: string;
+  status: string;
+};
+
+type FormValues = {
+  id: string;
+  eventName: string;
+  location: string;
+  locationLink: string;
+  volunteerSignUpCap: string;
+  defaultHoursAwarded: string;
+  eventDescription: string;
+  imageURL: string;
+  rsvpLinkImage: string;
+  startDate: dayjs.Dayjs;
+  startTime: dayjs.Dayjs;
+  endTime: dayjs.Dayjs;
   mode: string;
   status: string;
 };
@@ -115,9 +133,9 @@ const EventForm = ({
             eventDescription: eventDetails.eventDescription,
             imageURL: eventDetails.imageURL,
             rsvpLinkImage: eventDetails.rsvpLinkImage,
-            startDate: eventDetails.startDate,
-            startTime: eventDetails.startTime,
-            endTime: eventDetails.endTime,
+            startDate: dayjs(eventDetails.startDate),
+            startTime: dayjs(eventDetails.startTime),
+            endTime: dayjs(eventDetails.endTime),
           },
         }
       : {}
@@ -294,11 +312,10 @@ const EventForm = ({
     }
   };
 
-  /** Performs validation to ensure event starts after current time */
+  /** Performs validation to ensure event ends after current time */
   const timeAndDateValidation = () => {
-    const { startTime, startDate } = getValues();
-    const startDateTime = convertToISO(startTime, startDate);
-    if (new Date(startDateTime) <= new Date()) {
+    const { endTime } = getValues();
+    if (endTime.toDate() <= new Date()) {
       setErrorNotificationOpen(true);
       setErrorMessage("Created event cannot be in the past.");
       return false;
@@ -334,7 +351,7 @@ const EventForm = ({
   /** Edit event "Save changes" button should be disabled if event is in the past */
   const currentDate = new Date();
   const eventIsPast = eventDetails
-    ? new Date(eventDetails?.startDate) < currentDate
+    ? new Date(eventDetails?.endTime) < currentDate
     : false;
 
   /** Check if this event has been canceled */
@@ -361,8 +378,8 @@ const EventForm = ({
       {eventType == "edit" && eventIsPast && (
         <div className="pb-6">
           <Alert variety="warning">
-            This event has already started or is in the past. You are not able
-            to make changes or cancel the event.
+            This event has concluded. You are not able to make changes or cancel
+            the event.
           </Alert>
         </div>
       )}

--- a/frontend/src/components/organisms/ManageAttendees.tsx
+++ b/frontend/src/components/organisms/ManageAttendees.tsx
@@ -34,7 +34,7 @@ import PersonIcon from "@mui/icons-material/Person";
 import EditIcon from "@mui/icons-material/Edit";
 import TextCopy from "../atoms/TextCopy";
 import { formatDateTimeToUI, formatDateTimeRange } from "@/utils/helpers";
-import { EventData } from "@/utils/types";
+import { EventData, EventDTO } from "@/utils/types";
 import { BASE_URL_CLIENT } from "@/utils/constants";
 import useWebSocket from "react-use-websocket";
 import { BASE_WEBSOCKETS_URL } from "@/utils/constants";
@@ -46,6 +46,7 @@ import Loading from "../molecules/Loading";
 import Switch from "@mui/material/Switch";
 import TextField from "../atoms/TextField";
 import InfoOutlineIcon from "@mui/icons-material/InfoOutlined";
+import dayjs from "dayjs";
 
 type attendeeData = {
   id: number;
@@ -73,9 +74,9 @@ interface AttendeesTableProps {
 }
 
 type FormValues = {
-  startDate: Date;
-  startTime: Date;
-  endTime: Date;
+  startDate: dayjs.Dayjs;
+  startTime: dayjs.Dayjs;
+  endTime: dayjs.Dayjs;
 };
 
 interface ViewCancelMessageModalBodyProps {
@@ -203,6 +204,7 @@ const AttendeesTable = ({
     }
   };
 
+  const currentDate = new Date();
   const eventColumns: GridColDef[] = [
     {
       field: "firstName",
@@ -262,7 +264,8 @@ const AttendeesTable = ({
             size="small"
             disabled={
               eventData.status === "CANCELED" ||
-              attendeesStatus === "CHECKED_OUT"
+              (attendeesStatus === "CHECKED_OUT" &&
+                currentDate > eventData.endDate)
             }
             value={params.row.status}
             onChange={(event: any) =>
@@ -416,8 +419,8 @@ const AttendeesTable = ({
           Volunteers are <b>checked out</b> when they leave the volunteer event.
           Only volunteers listed in this category have their hours tracked for
           the event. Once volunteers are checked out, their status{" "}
-          <b>cannot be changed</b> by supervisors, so make sure you are not
-          making any mistakes.
+          <b>cannot be changed</b> after the event concludes, so make sure you
+          are not making any mistakes.
         </p>
       ) : attendeesStatus === "CANCELED" ? (
         <p>
@@ -497,7 +500,7 @@ const DuplicateEventModalBody = ({
   setErrorNotificationOpen,
 }: {
   handleClose: () => void;
-  eventDetails?: FormValues;
+  eventDetails?: EventDTO;
   eventid: string;
   setErrorMessage: React.Dispatch<React.SetStateAction<string>>;
   setErrorNotificationOpen: React.Dispatch<React.SetStateAction<boolean>>;
@@ -518,9 +521,9 @@ const DuplicateEventModalBody = ({
     eventDetails
       ? {
           defaultValues: {
-            startDate: eventDetails.startDate,
-            startTime: eventDetails.startTime,
-            endTime: eventDetails.endTime,
+            startDate: dayjs(eventDetails.startDate),
+            startTime: dayjs(eventDetails.startDate),
+            endTime: dayjs(eventDetails.endDate),
           },
         }
       : {}
@@ -1105,6 +1108,7 @@ const ManageAttendees = () => {
         handleClose={handleClose}
         children={
           <DuplicateEventModalBody
+            eventDetails={eventData}
             eventid={eventid}
             handleClose={handleClose}
             setErrorMessage={setErrorMessage}

--- a/frontend/src/components/organisms/ManageAttendees.tsx
+++ b/frontend/src/components/organisms/ManageAttendees.tsx
@@ -265,7 +265,7 @@ const AttendeesTable = ({
             disabled={
               eventData.status === "CANCELED" ||
               (attendeesStatus === "CHECKED_OUT" &&
-                currentDate > eventData.endDate)
+                currentDate > new Date(eventData.endDate))
             }
             value={params.row.status}
             onChange={(event: any) =>

--- a/frontend/src/components/organisms/ViewEventDetails.tsx
+++ b/frontend/src/components/organisms/ViewEventDetails.tsx
@@ -251,7 +251,7 @@ const ViewEventDetails = () => {
                 eventId={eventid}
                 overCapacity={registeredVolunteersNumber === capacity}
                 attendeeId={userid}
-                date={new Date(eventData.startDate)}
+                date={new Date(eventData.endDate)}
                 eventCanceled={event_status === "CANCELED"}
                 attendeeBlacklisted={userBlacklisted}
               />

--- a/frontend/src/utils/helpers.ts
+++ b/frontend/src/utils/helpers.ts
@@ -77,11 +77,11 @@ export const formatDateString = (dateString: string) => {
  * @returns the ISO string
  */
 export const convertToISO = (
-  inputTime: Date | string,
-  inputDate: Date | string
+  inputTime: dayjs.Dayjs,
+  inputDate: dayjs.Dayjs
 ) => {
-  const date = format(new Date(inputDate), "yyyy-MM-dd");
-  const time = format(new Date(inputTime), "HH:mm:ss");
+  const date = format(inputDate.toDate(), "yyyy-MM-dd");
+  const time = format(inputTime.toDate(), "HH:mm:ss");
 
   return dayjs(`${date} ${time}`).toJSON();
 };


### PR DESCRIPTION
## Summary

Closes: change it so that supervisors/admins can still edit events after events have started (but keep it so they can't edit events that have CONCLUDED)

had to fix a bunch of random date issues that bugged out in EventForm as a result of this, also changed backend API to allow modifying event properties before the endDate. Also randomly fixed the duplicate event modal not populating the date properly as well.