### PR TITLE
Fix past events not fetching data in mobile view

### DIFF
--- a/frontend/src/utils/useViewEventState.ts
+++ b/frontend/src/utils/useViewEventState.ts
@@ -12,18 +12,16 @@ import {
 } from "@/utils/helpers";
 import { GridPaginationModel, GridSortModel } from "@mui/x-data-grid";
 import { eventHours } from "@/utils/helpers";
-import { fetchUserIdFromDatabase, formatDateString } from "@/utils/helpers";
+import { formatDateString } from "@/utils/helpers";
 import { useAuth } from "@/utils/AuthContext";
 
 function useViewEventState(
   role: "Supervisor" | "Volunteer" | "Admin",
   state: "upcoming" | "past",
-  seeAllEvents: boolean
+  seeAllEvents: boolean,
+  userid: string
 ) {
   const queryClient = useQueryClient();
-
-  const { user } = useAuth();
-  const [userid, setUserid] = useState<string>("");
 
   /** Tanstack query for fetching the user's total hours */
   const hoursQuery = useQuery({
@@ -82,9 +80,7 @@ function useViewEventState(
       sortModel[0].field,
     ],
     queryFn: async () => {
-      const userid = await fetchUserIdFromDatabase(user?.email as string);
       const hours = await api.get(`/users/${userid}/hours`);
-      setUserid(userid);
       return await fetchBatchOfEvents(userid);
     },
     placeholderData: keepPreviousData,


### PR DESCRIPTION
## Summary

This used to be broken, because the userid was a state variable that was not set properly

Closes: for reference hour and certificate hour tracker, when viewing from mobile width, hours are shown as NaN instead of 0 hours 0 min.

![image](https://github.com/user-attachments/assets/8d9ed633-76f3-470e-ad7a-dedd04a5d3f9)
