### PR TITLE
Increase table padding

### DIFF
--- a/frontend/src/components/organisms/ManageUsers.tsx
+++ b/frontend/src/components/organisms/ManageUsers.tsx
@@ -51,7 +51,7 @@ const Active = ({
       field: "firstName",
       headerName: "Name",
       flex: 1,
-      minWidth: 200,
+      minWidth: 250,
       renderHeader: (params) => (
         <div style={{ fontWeight: "bold" }}>{params.colDef.headerName}</div>
       ),
@@ -60,7 +60,7 @@ const Active = ({
       field: "email",
       headerName: "Email",
       flex: 1,
-      minWidth: 150,
+      minWidth: 250,
       renderHeader: (params) => (
         <div style={{ fontWeight: "bold" }}>{params.colDef.headerName}</div>
       ),
@@ -189,7 +189,7 @@ const Blacklisted = ({
       field: "firstName",
       headerName: "Name",
       flex: 2,
-      minWidth: 200,
+      minWidth: 250,
       renderHeader: (params) => (
         <div style={{ fontWeight: "bold" }}>{params.colDef.headerName}</div>
       ),
@@ -198,7 +198,7 @@ const Blacklisted = ({
       field: "email",
       headerName: "Email",
       flex: 1,
-      minWidth: 150,
+      minWidth: 250,
       renderHeader: (params) => (
         <div style={{ fontWeight: "bold" }}>{params.colDef.headerName}</div>
       ),

--- a/frontend/src/components/organisms/ViewEvents.tsx
+++ b/frontend/src/components/organisms/ViewEvents.tsx
@@ -249,7 +249,7 @@ const PastEvents = ({
       field: "name",
       headerName: "Event name",
       flex: 2,
-      minWidth: 100,
+      minWidth: 200,
       renderHeader: (params) => (
         <div style={{ fontWeight: "bold" }}>{params.colDef.headerName}</div>
       ),
@@ -271,7 +271,7 @@ const PastEvents = ({
       field: "startDate",
       headerName: "Date",
       flex: 0.5,
-      minWidth: 100,
+      minWidth: 120,
       renderHeader: (params) => (
         <div style={{ fontWeight: "bold" }}>{params.colDef.headerName}</div>
       ),
@@ -370,7 +370,8 @@ const PastEvents = ({
     {
       field: "startDate",
       headerName: "Date",
-      minWidth: 200,
+      minWidth: 120,
+      flex: 0.25,
       renderHeader: (params) => (
         <div style={{ fontWeight: "bold" }}>{params.colDef.headerName}</div>
       ),


### PR DESCRIPTION
## Summary

Increase table padding in the Past Events table

Closes: for past events table on mobile view, increase spacing/padding between columns so that text is legible