### PR TITLE
Add legacy hours tracker to Past Events

### DIFF
--- a/frontend/src/components/organisms/ViewEvents.tsx
+++ b/frontend/src/components/organisms/ViewEvents.tsx
@@ -237,6 +237,7 @@ const PastEvents = ({
     isPending,
     error,
     hours,
+    legacyHours,
     totalNumberofData,
     paginationModel,
     sortModel,
@@ -404,6 +405,7 @@ const PastEvents = ({
     <>
       {role === "Volunteer" && (
         <>
+          <h3>Hour Tracker</h3>
           <div className="grid gap-4 md:grid-cols-2 pb-4">
             <Card>
               <LinearProgress
@@ -439,6 +441,26 @@ const PastEvents = ({
               </div> */}
             </Card>
           </div>
+
+          <h3>Legacy Hours</h3>
+          <div className="grid gap-4 md:grid-cols-2 pb-4">
+            <Card>
+              <h3 className="mb-2 mt-0">Legacy Hour Tracker</h3>
+              <div>
+                You currently have {friendlyHours(legacyHours)} hours of
+                previous volunteer experience. These hours are stored outside of
+                the platform.
+              </div>
+            </Card>
+            <Card>
+              <h3 className="mb-2 mt-0">Active Hour Tracker</h3>
+              <div>
+                You currently have {friendlyHours(hours - legacyHours)} hours of
+                volunteer experience calculated from volunteer events recorded
+                on the platform.
+              </div>
+            </Card>
+          </div>
         </>
       )}
       <div>
@@ -449,6 +471,7 @@ const PastEvents = ({
               setSeeAllEvents={setSeeAllEvents}
               role={role}
             />
+            <h3>Event History</h3>
             <Card size="table" className="mt-5">
               <Table
                 columns={SupervisoreventColumns}
@@ -463,18 +486,21 @@ const PastEvents = ({
             </Card>
           </>
         ) : (
-          <Card size="table">
-            <Table
-              columns={volunteerEventColumns}
-              rows={rows}
-              dataSetLength={totalNumberofData}
-              paginationModel={paginationModel}
-              handlePaginationModelChange={handlePaginationModelChange}
-              handleSortModelChange={handleSortModelChange}
-              sortModel={sortModel}
-              loading={isPending}
-            />
-          </Card>
+          <>
+            <h3>Event History</h3>
+            <Card size="table">
+              <Table
+                columns={volunteerEventColumns}
+                rows={rows}
+                dataSetLength={totalNumberofData}
+                paginationModel={paginationModel}
+                handlePaginationModelChange={handlePaginationModelChange}
+                handleSortModelChange={handleSortModelChange}
+                sortModel={sortModel}
+                loading={isPending}
+              />
+            </Card>
+          </>
         )}
       </div>
     </>

--- a/frontend/src/components/organisms/ViewEvents.tsx
+++ b/frontend/src/components/organisms/ViewEvents.tsx
@@ -471,7 +471,6 @@ const PastEvents = ({
               setSeeAllEvents={setSeeAllEvents}
               role={role}
             />
-            <h3>Event History</h3>
             <Card size="table" className="mt-5">
               <Table
                 columns={SupervisoreventColumns}

--- a/frontend/src/utils/useViewEventState.ts
+++ b/frontend/src/utils/useViewEventState.ts
@@ -33,6 +33,23 @@ function useViewEventState(
   });
   let hours = hoursQuery.data;
 
+  /** Tanstack query for fetching the user profile data */
+  const {
+    data: userProfileDetailsQuery,
+    isPending: userProfileFetchPending,
+    isError: userProfileFetchHasError,
+  } = useQuery({
+    queryKey: ["user", userid],
+    queryFn: async () => {
+      const { data } = await api.get(`/users/${userid}`);
+      return data["data"];
+    },
+  });
+
+  let { legacyHours }: { legacyHours: number } = {
+    legacyHours: userProfileDetailsQuery?.legacyHours,
+  };
+
   /** Pagination model for the table */
   const [paginationModel, setPaginationModel] = useState<GridPaginationModel>({
     page: 0,
@@ -177,6 +194,7 @@ function useViewEventState(
     isPending: isPending || isPlaceholderData,
     error,
     hours,
+    legacyHours,
     totalNumberofData,
     paginationModel,
     sortModel,


### PR DESCRIPTION
## Summary

Closes: Add legacy hours to the volunteer view, not just the admin Manage Users view

![image](https://github.com/user-attachments/assets/36b01973-c380-416a-ac96-5f91e06c3262)