### PR TITLE
Fix websockets in ManageAttendees

### DIFF
--- a/backend/src/events/views.ts
+++ b/backend/src/events/views.ts
@@ -52,8 +52,8 @@ eventRouter.post(
   async (req: Request, res: Response) => {
     // #swagger.tags = ['Events']
     const eventDTO: EventDTO = req.body;
-    attempt(res, 201, () => eventController.createEvent(eventDTO));
-    socketNotify("/events");
+    await attempt(res, 201, () => eventController.createEvent(eventDTO));
+    await socketNotify("/events");
   }
 );
 
@@ -62,10 +62,10 @@ eventRouter.put(
   useSupervisorAdminAuth,
   async (req: Request, res: Response) => {
     // #swagger.tags = ['Events']
-    attempt(res, 200, () =>
+    await attempt(res, 200, () =>
       eventController.updateEvent(req.params.eventid, req.body)
     );
-    socketNotify(`/events/${req.params.eventid}`);
+    await socketNotify(`/events/${req.params.eventid}`);
   }
 );
 
@@ -142,10 +142,10 @@ eventRouter.post(
     // #swagger.tags = ['Events']
     const { attendeeid } = req.body;
     checkUserMatchOrSupervisorAdmin(req, res, attendeeid, async () => {
-      attempt(res, 200, () =>
+      await attempt(res, 200, () =>
         eventController.addAttendee(req.params.eventid, attendeeid)
       );
-      socketNotify(`/events/${req.params.eventid}`);
+      await socketNotify(`/events/${req.params.eventid}`);
     });
   }
 );
@@ -156,7 +156,7 @@ eventRouter.patch(
   async (req: Request, res: Response) => {
     // #swagger.tags = ['Events']
     const { attendeeStatus, customHours } = req.body;
-    attempt(res, 200, () =>
+    await attempt(res, 200, () =>
       eventController.updateEnrollmentStatus(
         req.params.eventid,
         req.params.userid,
@@ -164,7 +164,7 @@ eventRouter.patch(
         customHours
       )
     );
-    socketNotify(`/events/${req.params.eventid}`);
+    await socketNotify(`/events/${req.params.eventid}`);
   }
 );
 
@@ -179,14 +179,14 @@ eventRouter.put(
       req.params.attendeeid,
       async () => {
         const { cancelationMessage } = req.body;
-        attempt(res, 200, () =>
+        await attempt(res, 200, () =>
           eventController.deleteAttendee(
             req.params.eventid,
             req.params.attendeeid,
             cancelationMessage
           )
         );
-        socketNotify(`/events/${req.params.eventid}`);
+        await socketNotify(`/events/${req.params.eventid}`);
       }
     );
   }
@@ -198,10 +198,10 @@ eventRouter.patch(
   async (req: Request, res: Response) => {
     // #swagger.tags = ['Events']
     const { status } = req.body;
-    attempt(res, 200, () =>
+    await attempt(res, 200, () =>
       eventController.updateEventStatus(req.params.eventid, status)
     );
-    socketNotify(`/events/${req.params.eventid}`);
+    await socketNotify(`/events/${req.params.eventid}`);
   }
 );
 

--- a/backend/src/users/views.ts
+++ b/backend/src/users/views.ts
@@ -36,7 +36,7 @@ userRouter.post(
   NoAuth as RequestHandler,
   async (req: Request, res: Response) => {
     // #swagger.tags = ['Users']
-    socketNotify("/users");
+    await socketNotify("/users");
     let user;
     const { password, ...rest } = req.body;
     try {
@@ -92,7 +92,7 @@ userRouter.post(
   NoAuth as RequestHandler,
   async (req: Request, res: Response) => {
     // #swagger.tags = ['Users']
-    socketNotify("/users");
+    await socketNotify("/users");
     const { ...rest } = req.body;
     try {
       await firebase.auth().setCustomUserClaims(rest.id, {
@@ -116,8 +116,8 @@ userRouter.delete("/:userid", useAuth, async (req: Request, res: Response) => {
   // #swagger.tags = ['Users']
   checkUserMatchOrSupervisorAdmin(req, res, req.params.userid, async () => {
     await admin.auth().deleteUser(req.params.userid);
-    attempt(res, 200, () => userController.deleteUser(req.params.userid));
-    socketNotify("/users");
+    await attempt(res, 200, () => userController.deleteUser(req.params.userid));
+    await socketNotify("/users");
   });
 });
 
@@ -125,10 +125,10 @@ userRouter.put("/:userid", useAuth, async (req: Request, res: Response) => {
   // #swagger.tags = ['Users']
 
   // Do API call
-  attempt(res, 200, () =>
+  await attempt(res, 200, () =>
     userController.updateUser(req.params.userid, req.body)
   );
-  socketNotify(`/users/${req.params.userid}`);
+  await socketNotify(`/users/${req.params.userid}`);
 });
 
 userRouter.get("/", useAuth, async (req: Request, res: Response) => {
@@ -189,10 +189,10 @@ userRouter.put(
   async (req: Request, res: Response) => {
     // #swagger.tags = ['Users']
     checkUserMatchOrSupervisorAdmin(req, res, req.params.userid, async () => {
-      attempt(res, 200, () =>
+      await attempt(res, 200, () =>
         userController.editProfile(req.params.userid, req.body)
       );
-      socketNotify(`/users/${req.params.userid}`);
+      await socketNotify(`/users/${req.params.userid}`);
     });
   }
 );
@@ -203,10 +203,10 @@ userRouter.put(
   async (req: Request, res: Response) => {
     // #swagger.tags = ['Users']
     checkUserMatchOrSupervisorAdmin(req, res, req.params.userid, async () => {
-      attempt(res, 200, () =>
+      await attempt(res, 200, () =>
         userController.editPreferences(req.params.userid, req.body)
       );
-      socketNotify(`/users/${req.params.userid}`);
+      await socketNotify(`/users/${req.params.userid}`);
     });
   }
 );
@@ -217,10 +217,10 @@ userRouter.patch(
   async (req: Request, res: Response) => {
     // #swagger.tags = ['Users']
     const { status } = req.body;
-    attempt(res, 200, () =>
+    await attempt(res, 200, () =>
       userController.editStatus(req.params.userid, status)
     );
-    socketNotify(`/users/${req.params.userid}`);
+    await socketNotify(`/users/${req.params.userid}`);
   }
 );
 
@@ -230,10 +230,10 @@ userRouter.patch(
   async (req: Request, res: Response) => {
     // #swagger.tags = ['Users']
     const { legacyHours } = req.body;
-    attempt(res, 200, () =>
+    await attempt(res, 200, () =>
       userController.editLegacyHours(req.params.userid, legacyHours)
     );
-    socketNotify(`/users/${req.params.userid}`);
+    await socketNotify(`/users/${req.params.userid}`);
   }
 );
 
@@ -260,7 +260,7 @@ userRouter.patch(
         }
 
         const editRoleResponse = await userController.editRole(userid, role);
-        socketNotify(`/users/${req.params.userid}`);
+        await socketNotify(`/users/${req.params.userid}`);
         res.status(200).json(editRoleResponse);
       } else {
         throw new Error("User not found");

--- a/frontend/src/components/organisms/ManageAttendees.tsx
+++ b/frontend/src/components/organisms/ManageAttendees.tsx
@@ -174,17 +174,21 @@ const AttendeesTable = ({
   });
 
   //TODO: Proper handling of websocket messages
-  if (
-    lastMessage &&
-    lastMessage.data ==
-      `{"resource":"/events/${eventid}","message":"The resource has been updated!"}`
-  ) {
-    // Invalidate the Event Recap query to fetch new data
-    queryClient.invalidateQueries({ queryKey: ["event"] });
+  useEffect(() => {
+    if (
+      lastMessage &&
+      lastMessage.data ==
+        `{"resource":"/events/${eventid}","message":"The resource has been updated!"}`
+    ) {
+      console.log(lastMessage.data);
 
-    // Invalidate the Manage Attendees query to fetch new data
-    queryClient.invalidateQueries({ queryKey: [eventid] });
-  }
+      // Invalidate the Event Recap query to fetch new data
+      queryClient.invalidateQueries({ queryKey: ["event"] });
+
+      // Invalidate the Manage Attendees query to fetch new data
+      queryClient.invalidateQueries({ queryKey: [eventid] });
+    }
+  }, [lastMessage]);
 
   const handleStatusChange = async (
     userId: string,

--- a/frontend/src/components/organisms/ViewEventDetails.tsx
+++ b/frontend/src/components/organisms/ViewEventDetails.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import EventTemplate from "../templates/EventTemplate";
 import EventCardRegister from "./EventCardRegister";
 import Divider from "@mui/material/Divider";
@@ -47,14 +47,19 @@ const ViewEventDetails = () => {
   });
 
   // TODO: Proper handling of websocket messages
-  if (
-    lastMessage &&
-    lastMessage.data ==
-      `{"resource":"/events/${id}","message":"The resource has been updated!"}`
-  ) {
-    // Invalidate the number of registered volunteers query to fetch new data
-    queryClient.invalidateQueries({ queryKey: ["registeredVoluneers"] });
-  }
+  useEffect(() => {
+    if (
+      lastMessage &&
+      lastMessage.data ==
+        `{"resource":"/events/${id}","message":"The resource has been updated!"}`
+    ) {
+      // Invalidate the number of registered volunteers query to fetch new data
+      queryClient.invalidateQueries({ queryKey: ["registeredVolunteers"] });
+
+      // Invalidate the event data
+      queryClient.invalidateQueries({ queryKey: ["eventAttendance"] });
+    }
+  }, [lastMessage]);
 
   /** Tanstack query to fetch and update the event details */
   const { data, isLoading, isError, error } = useQuery({
@@ -92,7 +97,7 @@ const ViewEventDetails = () => {
   });
 
   const { data: registeredVolunteersNumber } = useQuery({
-    queryKey: ["registeredVoluneers", id],
+    queryKey: ["registeredVolunteers", id],
     queryFn: async () => {
       const { data } = await api.get(
         `/events/${id}/attendees/registered/length`

--- a/frontend/src/utils/useManageAttendeeState.ts
+++ b/frontend/src/utils/useManageAttendeeState.ts
@@ -88,6 +88,21 @@ export default function useManageAttendeeState(
       (attendee: any) => attendee.userId === user.id
     );
 
+    // Define custom hours
+    let customHours = "N/A";
+    if (
+      eventAttendance &&
+      eventAttendance.attendeeStatus === "CHECKED_OUT" &&
+      eventAttendance.customHours !== null
+    ) {
+      customHours = friendlyHours(eventAttendance.customHours);
+    } else if (
+      eventAttendance &&
+      eventAttendance.attendeeStatus === "CHECKED_OUT"
+    ) {
+      customHours = friendlyHours(defaultHours);
+    }
+
     rows.push({
       id: user.id,
       status: state,
@@ -95,13 +110,7 @@ export default function useManageAttendeeState(
       email: user.email,
       role: user.role,
       phone: user.profile?.phoneNumber || "N/A",
-      customHours:
-        eventAttendance.attendeeStatus === "CHECKED_OUT" &&
-        eventAttendance.customHours !== null
-          ? friendlyHours(eventAttendance.customHours)
-          : eventAttendance.attendeeStatus === "CHECKED_OUT"
-          ? friendlyHours(defaultHours)
-          : "N/A",
+      customHours: customHours,
     });
   });
 


### PR DESCRIPTION
## Summary

Websockets were broken for the longest time in ManageAttendees; if a user registered for an event, it did not show up. Spent like 3 hours debugging everything, useEffect chains, etc. to no avail, only to realize it was a simple async issue on the backend. the db was running `socketNotify` concurrently with the API call instead of awaiting the db action THEN running the socketnotify... so the queryinvalidation was being called too early.