### PR TITLE
Fix null image URL for duplicate event

### DIFF
--- a/frontend/src/components/organisms/ManageAttendees.tsx
+++ b/frontend/src/components/organisms/ManageAttendees.tsx
@@ -549,7 +549,7 @@ const DuplicateEventModalBody = ({
           location: `${data["data"].location}`,
           locationLink: `${data["data"].locationLink}`,
           description: `${data["data"].description}`,
-          imageURL: `${data["data"].imageURL}`,
+          imageURL: data["data"].imageURL,
           startDate: startDateTime,
           endDate: endDateTime,
           capacity: +data["data"].capacity,


### PR DESCRIPTION
## Summary

When no image was specified, duplicating an event would make a new event with imageURL "null" instead of `null`